### PR TITLE
Add real-data position sizing demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+backtestdata
 .env2
 .cache
 data

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+expresults.md
 backtestdata
 .env2
 .cache

--- a/comprehensive_backtest_real_gpu.py
+++ b/comprehensive_backtest_real_gpu.py
@@ -1,0 +1,430 @@
+#!/usr/bin/env python3
+"""
+Comprehensive backtesting system using real GPU forecasts and multiple position sizing strategies.
+This system integrates with the actual trade_stock_e2e trading logic to test various strategies.
+"""
+
+import pandas as pd
+import numpy as np
+import matplotlib.pyplot as plt
+import seaborn as sns
+from pathlib import Path
+import sys
+from datetime import datetime, timedelta
+from typing import Dict, List, Tuple, Optional
+import logging
+from concurrent.futures import ProcessPoolExecutor
+import warnings
+warnings.filterwarnings('ignore')
+
+# Add project root to path
+ROOT = Path(__file__).resolve().parent
+sys.path.append(str(ROOT))
+
+# Import actual trading modules
+from trade_stock_e2e import analyze_symbols, backtest_forecasts
+from src.position_sizing_optimizer import (
+    constant_sizing,
+    expected_return_sizing,
+    volatility_scaled_sizing,
+    top_n_expected_return_sizing,
+    backtest_position_sizing_series,
+    sharpe_ratio
+)
+
+# Set up logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+class ComprehensiveBacktester:
+    """
+    Comprehensive backtesting system that uses real GPU forecasts and multiple position sizing strategies.
+    """
+    
+    def __init__(self, symbols: List[str], start_date: str = None, end_date: str = None):
+        self.symbols = symbols
+        self.start_date = start_date or "2021-01-01"
+        self.end_date = end_date or datetime.now().strftime("%Y-%m-%d")
+        self.results = {}
+        
+    def get_real_gpu_forecasts(self, symbol: str, num_simulations: int = 100) -> pd.DataFrame:
+        """
+        Get real GPU forecasts for a symbol using the actual trading system.
+        This uses the same analyze_symbols function as the live trading system.
+        """
+        try:
+            logger.info(f"Getting real GPU forecasts for {symbol}")
+            
+            # Use the actual backtest_forecasts function from trade_stock_e2e
+            backtest_df = backtest_forecasts(symbol, num_simulations)
+            
+            # Calculate actual returns for the backtesting period
+            actual_returns = []
+            predicted_returns = []
+            
+            for idx, row in backtest_df.iterrows():
+                # Calculate actual return (next day's close / current close - 1)
+                actual_return = (row.get('next_close', row['close']) / row['close'] - 1) if row['close'] > 0 else 0
+                
+                # Calculate predicted return based on the model's prediction
+                predicted_return = (row['predicted_close'] / row['close'] - 1) if row['close'] > 0 else 0
+                
+                actual_returns.append(actual_return)
+                predicted_returns.append(predicted_return)
+            
+            # Create DataFrame with actual and predicted returns
+            df = pd.DataFrame({
+                'actual_return': actual_returns,
+                'predicted_return': predicted_returns,
+                'timestamp': pd.date_range(start=self.start_date, periods=len(actual_returns), freq='D')
+            })
+            
+            return df
+            
+        except Exception as e:
+            logger.error(f"Error getting GPU forecasts for {symbol}: {e}")
+            return pd.DataFrame()
+    
+    def get_all_forecasts(self) -> Dict[str, pd.DataFrame]:
+        """
+        Get GPU forecasts for all symbols.
+        """
+        all_forecasts = {}
+        
+        for symbol in self.symbols:
+            forecasts = self.get_real_gpu_forecasts(symbol)
+            if not forecasts.empty:
+                all_forecasts[symbol] = forecasts
+                logger.info(f"Got {len(forecasts)} forecasts for {symbol}")
+        
+        return all_forecasts
+    
+    def create_multi_asset_data(self, forecasts: Dict[str, pd.DataFrame]) -> Tuple[pd.DataFrame, pd.DataFrame]:
+        """
+        Create multi-asset actual and predicted returns DataFrames.
+        """
+        actual_data = {}
+        predicted_data = {}
+        
+        for symbol, df in forecasts.items():
+            if not df.empty:
+                actual_data[symbol] = df.set_index('timestamp')['actual_return']
+                predicted_data[symbol] = df.set_index('timestamp')['predicted_return']
+        
+        actual_df = pd.DataFrame(actual_data)
+        predicted_df = pd.DataFrame(predicted_data)
+        
+        # Align indices and forward fill missing values
+        common_index = actual_df.index.intersection(predicted_df.index)
+        actual_df = actual_df.loc[common_index].fillna(0)
+        predicted_df = predicted_df.loc[common_index].fillna(0)
+        
+        return actual_df, predicted_df
+    
+    def test_position_sizing_strategies(self, actual_df: pd.DataFrame, predicted_df: pd.DataFrame) -> Dict[str, pd.DataFrame]:
+        """
+        Test multiple position sizing strategies and return performance results.
+        """
+        strategies = {
+            'constant_1x': lambda p: constant_sizing(p, factor=1.0),
+            'constant_0.5x': lambda p: constant_sizing(p, factor=0.5),
+            'constant_2x': lambda p: constant_sizing(p, factor=2.0),
+            'expected_return_1x': lambda p: expected_return_sizing(p, risk_factor=1.0),
+            'expected_return_0.5x': lambda p: expected_return_sizing(p, risk_factor=0.5),
+            'expected_return_2x': lambda p: expected_return_sizing(p, risk_factor=2.0),
+            'volatility_scaled': lambda p: volatility_scaled_sizing(p, window=10),
+            'top_1_best': lambda p: top_n_expected_return_sizing(p, n=1, leverage=1.0),
+            'top_2_best': lambda p: top_n_expected_return_sizing(p, n=2, leverage=1.0),
+            'top_3_best': lambda p: top_n_expected_return_sizing(p, n=3, leverage=1.0),
+            'top_1_high_lev': lambda p: top_n_expected_return_sizing(p, n=1, leverage=2.0),
+            'balanced_k2': lambda p: predicted_df / 2,  # K-divisor approach
+            'balanced_k3': lambda p: predicted_df / 3,  # K-divisor approach
+            'balanced_k5': lambda p: predicted_df / 5,  # K-divisor approach
+        }
+        
+        results = {}
+        
+        for name, strategy_func in strategies.items():
+            logger.info(f"Testing strategy: {name}")
+            
+            try:
+                # Get position sizes
+                sizes = strategy_func(predicted_df)
+                
+                # Ensure sizes are properly clipped to reasonable bounds
+                sizes = sizes.clip(-5, 5)  # Reasonable leverage bounds
+                
+                # Calculate PnL series
+                pnl_series = backtest_position_sizing_series(
+                    actual_df, 
+                    predicted_df, 
+                    lambda _: sizes,
+                    trading_fee=0.001  # 0.1% trading fee
+                )
+                
+                # Calculate performance metrics
+                total_return = pnl_series.sum()
+                sharpe = sharpe_ratio(pnl_series, risk_free_rate=0.02)  # 2% risk-free rate
+                max_drawdown = self.calculate_max_drawdown(pnl_series.cumsum())
+                volatility = pnl_series.std() * np.sqrt(252)  # Annualized volatility
+                
+                results[name] = {
+                    'pnl_series': pnl_series,
+                    'cumulative_pnl': pnl_series.cumsum(),
+                    'total_return': total_return,
+                    'sharpe_ratio': sharpe,
+                    'max_drawdown': max_drawdown,
+                    'volatility': volatility,
+                    'num_trades': len(pnl_series),
+                    'win_rate': (pnl_series > 0).mean()
+                }
+                
+                logger.info(f"{name}: Total Return={total_return:.4f}, Sharpe={sharpe:.3f}, Max DD={max_drawdown:.4f}")
+                
+            except Exception as e:
+                logger.error(f"Error testing strategy {name}: {e}")
+                continue
+        
+        return results
+    
+    def calculate_max_drawdown(self, cumulative_pnl: pd.Series) -> float:
+        """Calculate maximum drawdown from cumulative PnL series."""
+        peak = cumulative_pnl.expanding().max()
+        drawdown = (cumulative_pnl - peak) / peak.abs()
+        return drawdown.min()
+    
+    def generate_performance_plots(self, results: Dict[str, Dict], output_dir: str = "backtest_results"):
+        """
+        Generate comprehensive performance plots and save them.
+        """
+        output_path = Path(output_dir)
+        output_path.mkdir(exist_ok=True)
+        
+        # Set up the plotting style
+        plt.style.use('seaborn-v0_8')
+        fig = plt.figure(figsize=(20, 24))
+        
+        # 1. Cumulative PnL Plot
+        ax1 = plt.subplot(4, 2, 1)
+        for name, metrics in results.items():
+            if 'cumulative_pnl' in metrics:
+                plt.plot(metrics['cumulative_pnl'], label=name, alpha=0.8)
+        plt.title('Cumulative PnL by Strategy', fontsize=14, fontweight='bold')
+        plt.xlabel('Time')
+        plt.ylabel('Cumulative PnL')
+        plt.legend(bbox_to_anchor=(1.05, 1), loc='upper left')
+        plt.grid(True, alpha=0.3)
+        
+        # 2. Risk-Return Scatter Plot
+        ax2 = plt.subplot(4, 2, 2)
+        returns = [metrics['total_return'] for metrics in results.values()]
+        risks = [metrics['volatility'] for metrics in results.values()]
+        names = list(results.keys())
+        
+        scatter = plt.scatter(risks, returns, c=range(len(names)), cmap='viridis', s=100, alpha=0.7)
+        for i, name in enumerate(names):
+            plt.annotate(name, (risks[i], returns[i]), xytext=(5, 5), textcoords='offset points', fontsize=8)
+        plt.title('Risk-Return Profile', fontsize=14, fontweight='bold')
+        plt.xlabel('Volatility (Risk)')
+        plt.ylabel('Total Return')
+        plt.grid(True, alpha=0.3)
+        
+        # 3. Sharpe Ratio Bar Chart
+        ax3 = plt.subplot(4, 2, 3)
+        sharpe_ratios = [metrics['sharpe_ratio'] for metrics in results.values()]
+        bars = plt.bar(names, sharpe_ratios, color='skyblue', alpha=0.8)
+        plt.title('Sharpe Ratio by Strategy', fontsize=14, fontweight='bold')
+        plt.ylabel('Sharpe Ratio')
+        plt.xticks(rotation=45, ha='right')
+        plt.grid(True, alpha=0.3)
+        
+        # Add value labels on bars
+        for bar, value in zip(bars, sharpe_ratios):
+            plt.text(bar.get_x() + bar.get_width()/2, bar.get_height() + 0.01, 
+                    f'{value:.3f}', ha='center', va='bottom', fontsize=8)
+        
+        # 4. Maximum Drawdown Bar Chart
+        ax4 = plt.subplot(4, 2, 4)
+        drawdowns = [metrics['max_drawdown'] for metrics in results.values()]
+        bars = plt.bar(names, drawdowns, color='lightcoral', alpha=0.8)
+        plt.title('Maximum Drawdown by Strategy', fontsize=14, fontweight='bold')
+        plt.ylabel('Max Drawdown')
+        plt.xticks(rotation=45, ha='right')
+        plt.grid(True, alpha=0.3)
+        
+        # Add value labels on bars
+        for bar, value in zip(bars, drawdowns):
+            plt.text(bar.get_x() + bar.get_width()/2, bar.get_height() - 0.01, 
+                    f'{value:.3f}', ha='center', va='top', fontsize=8)
+        
+        # 5. Win Rate Bar Chart
+        ax5 = plt.subplot(4, 2, 5)
+        win_rates = [metrics['win_rate'] for metrics in results.values()]
+        bars = plt.bar(names, win_rates, color='lightgreen', alpha=0.8)
+        plt.title('Win Rate by Strategy', fontsize=14, fontweight='bold')
+        plt.ylabel('Win Rate')
+        plt.xticks(rotation=45, ha='right')
+        plt.grid(True, alpha=0.3)
+        
+        # Add value labels on bars
+        for bar, value in zip(bars, win_rates):
+            plt.text(bar.get_x() + bar.get_width()/2, bar.get_height() + 0.01, 
+                    f'{value:.1%}', ha='center', va='bottom', fontsize=8)
+        
+        # 6. Rolling Sharpe Ratio
+        ax6 = plt.subplot(4, 2, 6)
+        for name, metrics in results.items():
+            if 'pnl_series' in metrics:
+                rolling_sharpe = metrics['pnl_series'].rolling(window=30).apply(lambda x: sharpe_ratio(x, risk_free_rate=0.02))
+                plt.plot(rolling_sharpe, label=name, alpha=0.7)
+        plt.title('30-Day Rolling Sharpe Ratio', fontsize=14, fontweight='bold')
+        plt.xlabel('Time')
+        plt.ylabel('Rolling Sharpe Ratio')
+        plt.legend(bbox_to_anchor=(1.05, 1), loc='upper left')
+        plt.grid(True, alpha=0.3)
+        
+        # 7. Performance Summary Table
+        ax7 = plt.subplot(4, 2, 7)
+        ax7.axis('tight')
+        ax7.axis('off')
+        
+        # Create performance summary table
+        table_data = []
+        for name, metrics in results.items():
+            table_data.append([
+                name,
+                f"{metrics['total_return']:.4f}",
+                f"{metrics['sharpe_ratio']:.3f}",
+                f"{metrics['max_drawdown']:.4f}",
+                f"{metrics['volatility']:.4f}",
+                f"{metrics['win_rate']:.1%}"
+            ])
+        
+        table = ax7.table(cellText=table_data,
+                         colLabels=['Strategy', 'Total Return', 'Sharpe', 'Max DD', 'Volatility', 'Win Rate'],
+                         cellLoc='center',
+                         loc='center')
+        table.auto_set_font_size(False)
+        table.set_fontsize(8)
+        table.scale(1.2, 1.5)
+        plt.title('Performance Summary', fontsize=14, fontweight='bold', pad=20)
+        
+        # 8. Distribution of Daily Returns
+        ax8 = plt.subplot(4, 2, 8)
+        for name, metrics in results.items():
+            if 'pnl_series' in metrics:
+                plt.hist(metrics['pnl_series'], bins=50, alpha=0.5, label=name, density=True)
+        plt.title('Distribution of Daily Returns', fontsize=14, fontweight='bold')
+        plt.xlabel('Daily Return')
+        plt.ylabel('Density')
+        plt.legend()
+        plt.grid(True, alpha=0.3)
+        
+        plt.tight_layout()
+        
+        # Save the comprehensive plot
+        output_file = output_path / f"comprehensive_backtest_results_{datetime.now().strftime('%Y%m%d_%H%M%S')}.png"
+        plt.savefig(output_file, dpi=300, bbox_inches='tight')
+        logger.info(f"Comprehensive results saved to {output_file}")
+        
+        # Save results to CSV
+        csv_data = []
+        for name, metrics in results.items():
+            csv_data.append({
+                'Strategy': name,
+                'Total_Return': metrics['total_return'],
+                'Sharpe_Ratio': metrics['sharpe_ratio'],
+                'Max_Drawdown': metrics['max_drawdown'],
+                'Volatility': metrics['volatility'],
+                'Win_Rate': metrics['win_rate'],
+                'Num_Trades': metrics['num_trades']
+            })
+        
+        results_df = pd.DataFrame(csv_data)
+        csv_file = output_path / f"backtest_results_{datetime.now().strftime('%Y%m%d_%H%M%S')}.csv"
+        results_df.to_csv(csv_file, index=False)
+        logger.info(f"Results CSV saved to {csv_file}")
+        
+        return output_file, csv_file
+    
+    def run_comprehensive_backtest(self, output_dir: str = "backtest_results"):
+        """
+        Run the comprehensive backtest with real GPU forecasts.
+        """
+        logger.info("Starting comprehensive backtest with real GPU forecasts...")
+        
+        # Get real GPU forecasts for all symbols
+        logger.info("Getting real GPU forecasts...")
+        forecasts = self.get_all_forecasts()
+        
+        if not forecasts:
+            logger.error("No forecasts available. Cannot run backtest.")
+            return
+        
+        logger.info(f"Got forecasts for {len(forecasts)} symbols")
+        
+        # Create multi-asset data
+        logger.info("Creating multi-asset data...")
+        actual_df, predicted_df = self.create_multi_asset_data(forecasts)
+        
+        if actual_df.empty or predicted_df.empty:
+            logger.error("No data available for backtesting.")
+            return
+        
+        logger.info(f"Created data with {len(actual_df)} time periods and {len(actual_df.columns)} assets")
+        
+        # Test position sizing strategies
+        logger.info("Testing position sizing strategies...")
+        results = self.test_position_sizing_strategies(actual_df, predicted_df)
+        
+        if not results:
+            logger.error("No strategy results available.")
+            return
+        
+        # Generate performance plots
+        logger.info("Generating performance plots...")
+        plot_file, csv_file = self.generate_performance_plots(results, output_dir)
+        
+        # Print summary
+        logger.info("\n" + "="*80)
+        logger.info("COMPREHENSIVE BACKTEST RESULTS SUMMARY")
+        logger.info("="*80)
+        
+        # Sort by Sharpe ratio
+        sorted_results = sorted(results.items(), key=lambda x: x[1]['sharpe_ratio'], reverse=True)
+        
+        for name, metrics in sorted_results[:5]:  # Top 5 strategies
+            logger.info(f"{name:20} | Return: {metrics['total_return']:8.4f} | Sharpe: {metrics['sharpe_ratio']:6.3f} | Max DD: {metrics['max_drawdown']:8.4f} | Win Rate: {metrics['win_rate']:6.1%}")
+        
+        logger.info("="*80)
+        logger.info(f"Results saved to: {plot_file}")
+        logger.info(f"CSV data saved to: {csv_file}")
+        
+        return results, plot_file, csv_file
+
+
+def main():
+    """
+    Main function to run the comprehensive backtest.
+    """
+    # Define symbols to test (same as in trade_stock_e2e.py)
+    symbols = [
+        "COUR", "GOOG", "TSLA", "NVDA", "AAPL", "U", "ADSK", "CRWD", 
+        "ADBE", "NET", "COIN", "MSFT", "NFLX", "UNIUSD", "ETHUSD", "BTCUSD"
+    ]
+    
+    # Create backtester
+    backtester = ComprehensiveBacktester(
+        symbols=symbols,
+        start_date="2023-01-01",
+        end_date="2024-12-31"
+    )
+    
+    # Run comprehensive backtest
+    results, plot_file, csv_file = backtester.run_comprehensive_backtest()
+    
+    return results, plot_file, csv_file
+
+
+if __name__ == "__main__":
+    main()

--- a/predict_stock_e2e.py
+++ b/predict_stock_e2e.py
@@ -38,10 +38,6 @@ retrain = True
 daily_predictions = DataFrame()
 daily_predictions_time = None
 
-# Configure loguru to print both UTC and EDT time, and write to both stdout and a log file
-import pytz
-import sys
-
 logger = setup_logging("predict_stock_e2e.log")
 
 @timeit
@@ -52,7 +48,7 @@ def do_forecasting():
     alpaca_clock = alpaca_wrapper.get_clock()
     if daily_predictions.empty and (
             daily_predictions_time is None or daily_predictions_time < datetime.now() - timedelta(days=1)) or (
-            'SAP' not in daily_predictions[
+            not daily_predictions.empty and 'SAP' not in daily_predictions[
         'instrument'].unique() and alpaca_clock.is_open):  # or if we dont have stocks like SAP in there?
         logger.info("Daily predictions are empty or stale, or key stock missing; attempting to regenerate.")
         daily_predictions_time = datetime.now()
@@ -91,7 +87,7 @@ def do_forecasting():
     logger.info("Proceeding to make trade suggestions.")
     make_trade_suggestions(daily_predictions, minute_predictions)
 
-COOLDOWN_PERIOD = timedelta(minutes=60)  # Adjust this value as needed
+COOLDOWN_PERIOD = timedelta(minutes=60)
 
 def close_profitable_trades(all_preds, positions, orders, change_settings=True):
     # global made_money_recently

--- a/predict_stock_forecasting.py
+++ b/predict_stock_forecasting.py
@@ -200,10 +200,6 @@ def make_predictions(input_data_path=None, pred_name='', retrain=False, alpaca_w
                     forecast = pipeline.predict(
                         context,
                         prediction_length,
-                        num_samples=20,
-                        temperature=1.0,
-                        top_k=4000,
-                        top_p=1.0,
                     )
                     low, median, high = np.quantile(forecast[0].numpy(), [0.1, 0.5, 0.9], axis=0)  # todo use spread?
                     predictions.append(median.item())

--- a/predict_stock_forecasting.py
+++ b/predict_stock_forecasting.py
@@ -27,7 +27,7 @@ from sklearn.preprocessing import MinMaxScaler
 
 from torch.utils.tensorboard import SummaryWriter
 
-from chronos import BaseChronosPipeline
+from src.models.toto_wrapper import TotoPipeline
 
 current_date_formatted = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
 tb_writer = SummaryWriter(log_dir=f"./logs/{current_date_formatted}")
@@ -38,15 +38,11 @@ pipeline = None
 def load_pipeline():
     global pipeline
     if pipeline is None:
-        pipeline = BaseChronosPipeline.from_pretrained(
-            # "amazon/chronos-t5-large" if not PAPER else "amazon/chronos-t5-tiny",
-            # "amazon/chronos-t5-tiny",
-            "amazon/chronos-bolt-base",
+        pipeline = TotoPipeline.from_pretrained(
+            "Datadog/Toto-Open-Base-1.0",
             device_map="cuda",  # use "cpu" for CPU inference and "mps" for Apple Silicon
             # torch_dtype=torch.bfloat16,
         )
-        pipeline.model = pipeline.model.eval()
-        # pipeline.model = torch.compile(pipeline.model)
 
 
 def load_stock_data_from_csv(csv_file_path: Path):

--- a/run_comprehensive_backtest.py
+++ b/run_comprehensive_backtest.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""
+Script to run comprehensive backtest with real GPU forecasts using .venv environment.
+"""
+
+import sys
+import os
+from pathlib import Path
+
+# Add project root to path
+ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(ROOT))
+
+# Set up environment
+os.environ['PYTHONPATH'] = str(ROOT)
+
+try:
+    from comprehensive_backtest_real_gpu import ComprehensiveBacktester
+    from src.advanced_position_sizing import get_all_advanced_strategies, get_dataframe_only_strategies
+    import logging
+    
+    # Set up logging
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    )
+    logger = logging.getLogger(__name__)
+    
+    def run_enhanced_backtest():
+        """Run the enhanced backtest with advanced strategies."""
+        
+        # Define test symbols (start with a smaller set for testing)
+        test_symbols = [
+            "AAPL", "GOOGL", "TSLA", "NVDA", "MSFT"
+        ]
+        
+        logger.info(f"Starting enhanced backtest with symbols: {test_symbols}")
+        
+        # Create enhanced backtester
+        backtester = ComprehensiveBacktester(
+            symbols=test_symbols,
+            start_date="2023-01-01",
+            end_date="2024-12-31"
+        )
+        
+        # Override the test_position_sizing_strategies method to include advanced strategies
+        original_test_method = backtester.test_position_sizing_strategies
+        
+        def enhanced_test_strategies(actual_df, predicted_df):
+            """Enhanced version with advanced strategies."""
+            logger.info("Testing enhanced position sizing strategies...")
+            
+            # Get original strategies
+            results = original_test_method(actual_df, predicted_df)
+            
+            # Add advanced strategies
+            advanced_strategies = get_all_advanced_strategies()
+            dataframe_strategies = get_dataframe_only_strategies()
+            
+            # Test advanced strategies
+            for name, strategy_func in advanced_strategies.items():
+                logger.info(f"Testing advanced strategy: {name}")
+                try:
+                    sizes = strategy_func(predicted_df)
+                    sizes = sizes.clip(-3, 3)  # Reasonable bounds
+                    
+                    from src.position_sizing_optimizer import backtest_position_sizing_series, sharpe_ratio
+                    
+                    pnl_series = backtest_position_sizing_series(
+                        actual_df, 
+                        predicted_df, 
+                        lambda _: sizes,
+                        trading_fee=0.001
+                    )
+                    
+                    # Calculate metrics
+                    total_return = pnl_series.sum()
+                    sharpe = sharpe_ratio(pnl_series, risk_free_rate=0.02)
+                    max_drawdown = backtester.calculate_max_drawdown(pnl_series.cumsum())
+                    volatility = pnl_series.std() * (252**0.5)
+                    
+                    results[f"advanced_{name}"] = {
+                        'pnl_series': pnl_series,
+                        'cumulative_pnl': pnl_series.cumsum(),
+                        'total_return': total_return,
+                        'sharpe_ratio': sharpe,
+                        'max_drawdown': max_drawdown,
+                        'volatility': volatility,
+                        'num_trades': len(pnl_series),
+                        'win_rate': (pnl_series > 0).mean()
+                    }
+                    
+                    logger.info(f"advanced_{name}: Return={total_return:.4f}, Sharpe={sharpe:.3f}")
+                    
+                except Exception as e:
+                    logger.error(f"Error with advanced strategy {name}: {e}")
+                    continue
+            
+            # Test DataFrame-only strategies
+            for name, strategy_func in dataframe_strategies.items():
+                logger.info(f"Testing DataFrame strategy: {name}")
+                try:
+                    sizes = strategy_func(predicted_df)
+                    sizes = sizes.clip(-3, 3)
+                    
+                    pnl_series = backtest_position_sizing_series(
+                        actual_df, 
+                        predicted_df, 
+                        lambda _: sizes,
+                        trading_fee=0.001
+                    )
+                    
+                    # Calculate metrics
+                    total_return = pnl_series.sum()
+                    sharpe = sharpe_ratio(pnl_series, risk_free_rate=0.02)
+                    max_drawdown = backtester.calculate_max_drawdown(pnl_series.cumsum())
+                    volatility = pnl_series.std() * (252**0.5)
+                    
+                    results[f"df_{name}"] = {
+                        'pnl_series': pnl_series,
+                        'cumulative_pnl': pnl_series.cumsum(),
+                        'total_return': total_return,
+                        'sharpe_ratio': sharpe,
+                        'max_drawdown': max_drawdown,
+                        'volatility': volatility,
+                        'num_trades': len(pnl_series),
+                        'win_rate': (pnl_series > 0).mean()
+                    }
+                    
+                    logger.info(f"df_{name}: Return={total_return:.4f}, Sharpe={sharpe:.3f}")
+                    
+                except Exception as e:
+                    logger.error(f"Error with DataFrame strategy {name}: {e}")
+                    continue
+            
+            return results
+        
+        # Replace the method
+        backtester.test_position_sizing_strategies = enhanced_test_strategies
+        
+        # Run the enhanced backtest
+        logger.info("Running enhanced comprehensive backtest...")
+        results, plot_file, csv_file = backtester.run_comprehensive_backtest("enhanced_backtest_results")
+        
+        logger.info("Enhanced backtest completed successfully!")
+        return results, plot_file, csv_file
+    
+    def run_quick_test():
+        """Run a quick test with limited data."""
+        logger.info("Running quick test...")
+        
+        # Just test with AAPL for now
+        backtester = ComprehensiveBacktester(
+            symbols=["AAPL"],
+            start_date="2024-01-01",
+            end_date="2024-06-30"
+        )
+        
+        try:
+            results, plot_file, csv_file = backtester.run_comprehensive_backtest("quick_test_results")
+            logger.info("Quick test completed successfully!")
+            return results, plot_file, csv_file
+        except Exception as e:
+            logger.error(f"Quick test failed: {e}")
+            return None, None, None
+    
+    if __name__ == "__main__":
+        import argparse
+        
+        parser = argparse.ArgumentParser(description="Run comprehensive backtest")
+        parser.add_argument("--quick", action="store_true", help="Run quick test with limited data")
+        parser.add_argument("--enhanced", action="store_true", help="Run enhanced backtest with advanced strategies")
+        args = parser.parse_args()
+        
+        if args.quick:
+            run_quick_test()
+        elif args.enhanced:
+            run_enhanced_backtest()
+        else:
+            # Run standard backtest
+            from comprehensive_backtest_real_gpu import main
+            main()
+
+except ImportError as e:
+    print(f"Import error: {e}")
+    print("Make sure you're running from the project root directory and .venv is activated")
+    sys.exit(1)
+except Exception as e:
+    print(f"Error: {e}")
+    sys.exit(1)

--- a/run_comprehensive_backtest_csv.py
+++ b/run_comprehensive_backtest_csv.py
@@ -1,0 +1,582 @@
+#!/usr/bin/env python3
+"""
+Comprehensive backtesting system using real CSV prediction files and multiple position sizing strategies.
+This system works with the actual generated prediction CSV files to test various trading strategies.
+"""
+
+import pandas as pd
+import numpy as np
+import matplotlib.pyplot as plt
+from pathlib import Path
+import sys
+from datetime import datetime
+from typing import Dict, List, Tuple, Optional
+import logging
+import warnings
+import ast
+import re
+
+warnings.filterwarnings('ignore')
+
+# Add project root to path
+ROOT = Path(__file__).resolve().parent
+sys.path.append(str(ROOT))
+
+# Import actual trading modules
+from src.position_sizing_optimizer import (
+    constant_sizing,
+    expected_return_sizing,
+    volatility_scaled_sizing,
+    top_n_expected_return_sizing,
+    backtest_position_sizing_series,
+    sharpe_ratio
+)
+
+# Set up logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+class CSVBacktester:
+    """
+    Comprehensive backtesting system that uses real CSV prediction files and multiple position sizing strategies.
+    """
+    
+    def __init__(self, results_dir: str = "results", output_dir: str = "backtest_results"):
+        self.results_dir = Path(results_dir)
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(exist_ok=True)
+        self.results = {}
+        
+    def load_prediction_csvs(self, limit_files: Optional[int] = None) -> Dict[str, pd.DataFrame]:
+        """
+        Load prediction CSV files from the results directory.
+        """
+        csv_files = list(self.results_dir.glob("predictions-*.csv"))
+        csv_files = sorted(csv_files, key=lambda x: x.name)
+        
+        if limit_files:
+            csv_files = csv_files[-limit_files:]  # Take the most recent files
+            
+        logger.info(f"Loading {len(csv_files)} prediction CSV files...")
+        
+        all_predictions = {}
+        
+        for csv_file in csv_files:
+            try:
+                df = pd.read_csv(csv_file)
+                timestamp = self.extract_timestamp_from_filename(csv_file.name)
+                
+                # Process each row (instrument) in the CSV
+                for _, row in df.iterrows():
+                    instrument = row['instrument']
+                    
+                    if instrument not in all_predictions:
+                        all_predictions[instrument] = []
+                    
+                    # Extract the actual movements and predictions
+                    prediction_data = self.extract_prediction_data(row, timestamp)
+                    if prediction_data:
+                        all_predictions[instrument].append(prediction_data)
+                        
+            except Exception as e:
+                logger.warning(f"Error loading {csv_file}: {e}")
+                continue
+        
+        # Convert to DataFrames
+        processed_predictions = {}
+        for instrument, data_list in all_predictions.items():
+            if len(data_list) > 10:  # Only include instruments with sufficient data
+                df = pd.DataFrame(data_list)
+                df = df.sort_values('timestamp').reset_index(drop=True)
+                processed_predictions[instrument] = df
+                logger.info(f"Loaded {len(df)} predictions for {instrument}")
+        
+        return processed_predictions
+    
+    def extract_timestamp_from_filename(self, filename: str) -> datetime:
+        """Extract timestamp from prediction CSV filename."""
+        # Format: predictions-2023-06-23_12-13-09.csv
+        match = re.search(r'predictions-(\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})\.csv', filename)
+        if match:
+            timestamp_str = match.group(1)
+            return datetime.strptime(timestamp_str, "%Y-%m-%d_%H-%M-%S")
+        return datetime.now()
+    
+    def extract_prediction_data(self, row, timestamp: datetime) -> Optional[Dict]:
+        """Extract prediction and actual movement data from CSV row."""
+        try:
+            # Parse the tensor strings to get actual values
+            close_actuals = self.parse_tensor_string(row['close_actual_movement_values'])
+            close_predictions = self.parse_tensor_string(row['close_predictions'])
+            
+            if close_actuals is None or close_predictions is None:
+                return None
+            
+            # Calculate additional metrics
+            data = {
+                'timestamp': timestamp,
+                'instrument': row['instrument'],
+                'close_last_price': row['close_last_price'],
+                'close_predicted_price': row['close_predicted_price'],
+                'close_actual_movements': close_actuals,
+                'close_predictions': close_predictions,
+                'close_val_loss': row['close_val_loss'],
+                'takeprofit_profit': row.get('takeprofit_profit', 0),
+                'entry_takeprofit_profit': row.get('entry_takeprofit_profit', 0),
+                'maxdiffprofit_profit': row.get('maxdiffprofit_profit', 0),
+            }
+            
+            # Add high/low data if available
+            if 'high_actual_movement_values' in row and pd.notna(row['high_actual_movement_values']):
+                data['high_actual_movements'] = self.parse_tensor_string(row['high_actual_movement_values'])
+                data['high_predictions'] = self.parse_tensor_string(row['high_predictions'])
+            
+            if 'low_actual_movement_values' in row and pd.notna(row['low_actual_movement_values']):
+                data['low_actual_movements'] = self.parse_tensor_string(row['low_actual_movement_values'])
+                data['low_predictions'] = self.parse_tensor_string(row['low_predictions'])
+            
+            return data
+            
+        except Exception as e:
+            logger.debug(f"Error extracting data for {row.get('instrument', 'unknown')}: {e}")
+            return None
+    
+    def parse_tensor_string(self, tensor_str) -> Optional[List[float]]:
+        """Parse tensor string like 'tensor([0.1, -0.2, 0.3])' to list of floats."""
+        if pd.isna(tensor_str) or not isinstance(tensor_str, str):
+            return None
+        
+        try:
+            # Remove 'tensor(' and ')' and parse the list
+            tensor_str = tensor_str.strip()
+            if tensor_str.startswith('tensor('):
+                tensor_str = tensor_str[7:-1]  # Remove 'tensor(' and ')'
+            
+            # Handle the list format
+            if tensor_str.startswith('[') and tensor_str.endswith(']'):
+                # Use ast.literal_eval for safe evaluation
+                values = ast.literal_eval(tensor_str)
+                return [float(v) for v in values]
+            
+        except Exception as e:
+            logger.debug(f"Error parsing tensor string '{tensor_str}': {e}")
+            
+        return None
+    
+    def create_multi_asset_data(self, predictions: Dict[str, pd.DataFrame]) -> Tuple[pd.DataFrame, pd.DataFrame]:
+        """
+        Create multi-asset actual and predicted returns DataFrames using the prediction sequence data.
+        """
+        actual_data = {}
+        predicted_data = {}
+        
+        for instrument, df in predictions.items():
+            if len(df) < 5:  # Need minimum data
+                continue
+                
+            # Use the prediction sequence data (each row has a sequence of 6-7 predictions/actuals)
+            instrument_actuals = []
+            instrument_predictions = []
+            timestamps = []
+            
+            for _, row in df.iterrows():
+                # Each row contains a sequence, we'll use the last prediction/actual from each sequence
+                if row['close_actual_movements'] and row['close_predictions']:
+                    # Take the last value from each sequence as the "next day" prediction
+                    actual_return = row['close_actual_movements'][-1] if row['close_actual_movements'] else 0
+                    predicted_return = row['close_predictions'][-1] if row['close_predictions'] else 0
+                    
+                    instrument_actuals.append(actual_return)
+                    instrument_predictions.append(predicted_return)
+                    timestamps.append(row['timestamp'])
+            
+            if len(instrument_actuals) > 5:  # Minimum threshold
+                # Create index from timestamps
+                actual_series = pd.Series(instrument_actuals, index=timestamps, name=instrument)
+                predicted_series = pd.Series(instrument_predictions, index=timestamps, name=instrument)
+                
+                actual_data[instrument] = actual_series
+                predicted_data[instrument] = predicted_series
+        
+        if not actual_data:
+            logger.error("No valid data found for backtesting")
+            return pd.DataFrame(), pd.DataFrame()
+        
+        # Create DataFrames and align
+        actual_df = pd.DataFrame(actual_data)
+        predicted_df = pd.DataFrame(predicted_data)
+        
+        # Align indices and forward fill missing values
+        common_index = actual_df.index.intersection(predicted_df.index)
+        if len(common_index) == 0:
+            logger.error("No common timestamps found")
+            return pd.DataFrame(), pd.DataFrame()
+            
+        actual_df = actual_df.loc[common_index].fillna(0)
+        predicted_df = predicted_df.loc[common_index].fillna(0)
+        
+        logger.info(f"Created multi-asset data with {len(actual_df)} time periods and {len(actual_df.columns)} assets")
+        
+        return actual_df, predicted_df
+    
+    def test_position_sizing_strategies(self, actual_df: pd.DataFrame, predicted_df: pd.DataFrame) -> Dict[str, pd.DataFrame]:
+        """
+        Test multiple position sizing strategies and return performance results.
+        """
+        strategies = {
+            # Basic strategies
+            'constant_1x': lambda p: constant_sizing(p, factor=1.0),
+            'constant_0.5x': lambda p: constant_sizing(p, factor=0.5),
+            'constant_2x': lambda p: constant_sizing(p, factor=2.0),
+            
+            # Expected return strategies
+            'expected_return_1x': lambda p: expected_return_sizing(p, risk_factor=1.0),
+            'expected_return_0.5x': lambda p: expected_return_sizing(p, risk_factor=0.5),
+            'expected_return_2x': lambda p: expected_return_sizing(p, risk_factor=2.0),
+            'expected_return_5x': lambda p: expected_return_sizing(p, risk_factor=5.0),
+            
+            # Volatility-based strategies
+            'volatility_scaled': lambda p: volatility_scaled_sizing(p, window=10),
+            'volatility_scaled_5d': lambda p: volatility_scaled_sizing(p, window=5),
+            'volatility_scaled_20d': lambda p: volatility_scaled_sizing(p, window=20),
+            
+            # Top-N strategies  
+            'top_1_best': lambda p: top_n_expected_return_sizing(p, n=1, leverage=1.0),
+            'top_2_best': lambda p: top_n_expected_return_sizing(p, n=2, leverage=1.0),
+            'top_3_best': lambda p: top_n_expected_return_sizing(p, n=3, leverage=1.0),
+            'top_1_high_lev': lambda p: top_n_expected_return_sizing(p, n=1, leverage=2.0),
+            'top_2_high_lev': lambda p: top_n_expected_return_sizing(p, n=2, leverage=2.0),
+            
+            # K-divisor approaches (balanced exposure)
+            'balanced_k2': lambda p: predicted_df / 2,
+            'balanced_k3': lambda p: predicted_df / 3,
+            'balanced_k5': lambda p: predicted_df / 5,
+            'balanced_k10': lambda p: predicted_df / 10,
+            
+            # Sign-only strategies (direction only)
+            'sign_only': lambda p: np.sign(predicted_df),
+            'sign_scaled_0.5': lambda p: np.sign(predicted_df) * 0.5,
+            
+            # Threshold strategies
+            'threshold_01': lambda p: predicted_df * (predicted_df.abs() > 0.01),
+            'threshold_02': lambda p: predicted_df * (predicted_df.abs() > 0.02),
+            'threshold_05': lambda p: predicted_df * (predicted_df.abs() > 0.05),
+            
+            # Best absolute predictions
+            'abs_best_1': lambda p: self.get_absolute_best_n(predicted_df, n=1),
+            'abs_best_2': lambda p: self.get_absolute_best_n(predicted_df, n=2),
+            'abs_best_3': lambda p: self.get_absolute_best_n(predicted_df, n=3),
+        }
+        
+        results = {}
+        
+        for name, strategy_func in strategies.items():
+            logger.info(f"Testing strategy: {name}")
+            
+            try:
+                # Get position sizes
+                sizes = strategy_func(predicted_df)
+                
+                # Ensure sizes are properly clipped to reasonable bounds
+                sizes = sizes.clip(-5, 5)  # Reasonable leverage bounds
+                
+                # Calculate PnL series
+                pnl_series = backtest_position_sizing_series(
+                    actual_df, 
+                    predicted_df, 
+                    lambda _: sizes,
+                    trading_fee=0.001  # 0.1% trading fee
+                )
+                
+                # Calculate performance metrics
+                total_return = pnl_series.sum()
+                sharpe = sharpe_ratio(pnl_series, risk_free_rate=0.02)  # 2% risk-free rate
+                max_drawdown = self.calculate_max_drawdown(pnl_series.cumsum())
+                volatility = pnl_series.std() * np.sqrt(252)  # Annualized volatility
+                
+                results[name] = {
+                    'pnl_series': pnl_series,
+                    'cumulative_pnl': pnl_series.cumsum(),
+                    'total_return': total_return,
+                    'sharpe_ratio': sharpe,
+                    'max_drawdown': max_drawdown,
+                    'volatility': volatility,
+                    'num_trades': len(pnl_series),
+                    'win_rate': (pnl_series > 0).mean(),
+                    'avg_trade': pnl_series.mean(),
+                    'hit_rate': (pnl_series > 0).sum() / len(pnl_series) if len(pnl_series) > 0 else 0
+                }
+                
+                logger.info(f"{name}: Total Return={total_return:.4f}, Sharpe={sharpe:.3f}, Max DD={max_drawdown:.4f}")
+                
+            except Exception as e:
+                logger.error(f"Error testing strategy {name}: {e}")
+                continue
+        
+        return results
+    
+    def get_absolute_best_n(self, predicted_df: pd.DataFrame, n: int) -> pd.DataFrame:
+        """Get the n assets with highest absolute predicted returns."""
+        abs_pred = predicted_df.abs()
+        ranks = abs_pred.rank(axis=1, ascending=False, method='first')
+        selected = ranks <= n
+        
+        # Apply original signs
+        sizes = selected * np.sign(predicted_df)
+        
+        # Normalize by number of selected assets
+        counts = selected.sum(axis=1).replace(0, np.nan)
+        sizes = sizes.div(counts, axis=0).fillna(0.0)
+        
+        return sizes
+    
+    def calculate_max_drawdown(self, cumulative_pnl: pd.Series) -> float:
+        """Calculate maximum drawdown from cumulative PnL series."""
+        if len(cumulative_pnl) == 0:
+            return 0.0
+        peak = cumulative_pnl.expanding().max()
+        drawdown = (cumulative_pnl - peak) / np.maximum(peak.abs(), 1e-9)  # Avoid division by zero
+        return drawdown.min()
+    
+    def generate_performance_plots(self, results: Dict[str, Dict], output_dir: str = "backtest_results"):
+        """
+        Generate comprehensive performance plots and save them.
+        """
+        output_path = Path(output_dir)
+        output_path.mkdir(exist_ok=True)
+        
+        # Set up the plotting style
+        plt.style.use('default')
+        fig = plt.figure(figsize=(20, 24))
+        
+        # Filter out strategies with no valid results
+        valid_results = {k: v for k, v in results.items() if v['total_return'] != 0}
+        
+        if not valid_results:
+            logger.warning("No valid results to plot")
+            return None, None
+        
+        # 1. Cumulative PnL Plot
+        ax1 = plt.subplot(4, 2, 1)
+        for name, metrics in valid_results.items():
+            if 'cumulative_pnl' in metrics and len(metrics['cumulative_pnl']) > 0:
+                plt.plot(metrics['cumulative_pnl'], label=name, alpha=0.8)
+        plt.title('Cumulative PnL by Strategy', fontsize=14, fontweight='bold')
+        plt.xlabel('Time')
+        plt.ylabel('Cumulative PnL')
+        plt.legend(bbox_to_anchor=(1.05, 1), loc='upper left')
+        plt.grid(True, alpha=0.3)
+        
+        # 2. Risk-Return Scatter Plot
+        ax2 = plt.subplot(4, 2, 2)
+        returns = [metrics['total_return'] for metrics in valid_results.values()]
+        risks = [metrics['volatility'] for metrics in valid_results.values()]
+        names = list(valid_results.keys())
+        
+        scatter = plt.scatter(risks, returns, c=range(len(names)), cmap='viridis', s=100, alpha=0.7)
+        for i, name in enumerate(names):
+            if i < 10:  # Only annotate first 10 to avoid clutter
+                plt.annotate(name, (risks[i], returns[i]), xytext=(5, 5), textcoords='offset points', fontsize=8)
+        plt.title('Risk-Return Profile', fontsize=14, fontweight='bold')
+        plt.xlabel('Volatility (Risk)')
+        plt.ylabel('Total Return')
+        plt.grid(True, alpha=0.3)
+        
+        # 3. Sharpe Ratio Bar Chart
+        ax3 = plt.subplot(4, 2, 3)
+        sharpe_ratios = [metrics['sharpe_ratio'] for metrics in valid_results.values()]
+        names_short = [name[:10] for name in names]  # Truncate names for display
+        
+        bars = plt.bar(range(len(names_short)), sharpe_ratios, color='skyblue', alpha=0.8)
+        plt.title('Sharpe Ratio by Strategy', fontsize=14, fontweight='bold')
+        plt.ylabel('Sharpe Ratio')
+        plt.xticks(range(len(names_short)), names_short, rotation=45, ha='right')
+        plt.grid(True, alpha=0.3)
+        
+        # 4. Maximum Drawdown Bar Chart
+        ax4 = plt.subplot(4, 2, 4)
+        drawdowns = [metrics['max_drawdown'] for metrics in valid_results.values()]
+        bars = plt.bar(range(len(names_short)), drawdowns, color='lightcoral', alpha=0.8)
+        plt.title('Maximum Drawdown by Strategy', fontsize=14, fontweight='bold')
+        plt.ylabel('Max Drawdown')
+        plt.xticks(range(len(names_short)), names_short, rotation=45, ha='right')
+        plt.grid(True, alpha=0.3)
+        
+        # 5. Win Rate Bar Chart
+        ax5 = plt.subplot(4, 2, 5)
+        win_rates = [metrics['win_rate'] for metrics in valid_results.values()]
+        bars = plt.bar(range(len(names_short)), win_rates, color='lightgreen', alpha=0.8)
+        plt.title('Win Rate by Strategy', fontsize=14, fontweight='bold')
+        plt.ylabel('Win Rate')
+        plt.xticks(range(len(names_short)), names_short, rotation=45, ha='right')
+        plt.grid(True, alpha=0.3)
+        
+        # 6. Rolling Sharpe Ratio (for top 5 strategies)
+        ax6 = plt.subplot(4, 2, 6)
+        top_5_strategies = sorted(valid_results.items(), key=lambda x: x[1]['sharpe_ratio'], reverse=True)[:5]
+        
+        for name, metrics in top_5_strategies:
+            if 'pnl_series' in metrics and len(metrics['pnl_series']) > 30:
+                rolling_sharpe = metrics['pnl_series'].rolling(window=30).apply(lambda x: sharpe_ratio(x, risk_free_rate=0.02))
+                plt.plot(rolling_sharpe, label=name, alpha=0.7)
+        plt.title('30-Day Rolling Sharpe Ratio (Top 5)', fontsize=14, fontweight='bold')
+        plt.xlabel('Time')
+        plt.ylabel('Rolling Sharpe Ratio')
+        plt.legend(bbox_to_anchor=(1.05, 1), loc='upper left')
+        plt.grid(True, alpha=0.3)
+        
+        # 7. Performance Summary Table
+        ax7 = plt.subplot(4, 2, 7)
+        ax7.axis('tight')
+        ax7.axis('off')
+        
+        # Create performance summary table for top 10 strategies
+        top_10_strategies = sorted(valid_results.items(), key=lambda x: x[1]['sharpe_ratio'], reverse=True)[:10]
+        table_data = []
+        for name, metrics in top_10_strategies:
+            table_data.append([
+                name[:15],  # Truncate name
+                f"{metrics['total_return']:.4f}",
+                f"{metrics['sharpe_ratio']:.3f}",
+                f"{metrics['max_drawdown']:.4f}",
+                f"{metrics['volatility']:.4f}",
+                f"{metrics['win_rate']:.1%}"
+            ])
+        
+        table = ax7.table(cellText=table_data,
+                         colLabels=['Strategy', 'Total Return', 'Sharpe', 'Max DD', 'Volatility', 'Win Rate'],
+                         cellLoc='center',
+                         loc='center')
+        table.auto_set_font_size(False)
+        table.set_fontsize(8)
+        table.scale(1.2, 1.5)
+        plt.title('Performance Summary (Top 10)', fontsize=14, fontweight='bold', pad=20)
+        
+        # 8. Distribution of Daily Returns (top 3 strategies)
+        ax8 = plt.subplot(4, 2, 8)
+        top_3_strategies = sorted(valid_results.items(), key=lambda x: x[1]['sharpe_ratio'], reverse=True)[:3]
+        
+        for name, metrics in top_3_strategies:
+            if 'pnl_series' in metrics and len(metrics['pnl_series']) > 0:
+                plt.hist(metrics['pnl_series'], bins=30, alpha=0.5, label=name, density=True)
+        plt.title('Distribution of Daily Returns (Top 3)', fontsize=14, fontweight='bold')
+        plt.xlabel('Daily Return')
+        plt.ylabel('Density')
+        plt.legend()
+        plt.grid(True, alpha=0.3)
+        
+        plt.tight_layout()
+        
+        # Save the comprehensive plot
+        output_file = output_path / f"csv_backtest_results_{datetime.now().strftime('%Y%m%d_%H%M%S')}.png"
+        plt.savefig(output_file, dpi=300, bbox_inches='tight')
+        logger.info(f"Comprehensive results saved to {output_file}")
+        
+        # Save results to CSV
+        csv_data = []
+        for name, metrics in valid_results.items():
+            csv_data.append({
+                'Strategy': name,
+                'Total_Return': metrics['total_return'],
+                'Sharpe_Ratio': metrics['sharpe_ratio'],
+                'Max_Drawdown': metrics['max_drawdown'],
+                'Volatility': metrics['volatility'],
+                'Win_Rate': metrics['win_rate'],
+                'Num_Trades': metrics['num_trades'],
+                'Avg_Trade': metrics['avg_trade'],
+                'Hit_Rate': metrics['hit_rate']
+            })
+        
+        results_df = pd.DataFrame(csv_data)
+        results_df = results_df.sort_values('Sharpe_Ratio', ascending=False)
+        csv_file = output_path / f"csv_backtest_results_{datetime.now().strftime('%Y%m%d_%H%M%S')}.csv"
+        results_df.to_csv(csv_file, index=False)
+        logger.info(f"Results CSV saved to {csv_file}")
+        
+        plt.close()
+        
+        return output_file, csv_file
+    
+    def run_comprehensive_backtest(self, limit_files: Optional[int] = 50):
+        """
+        Run the comprehensive backtest with real CSV forecasts.
+        """
+        logger.info("Starting comprehensive backtest with CSV prediction files...")
+        
+        # Load prediction CSV files
+        logger.info("Loading prediction CSV files...")
+        predictions = self.load_prediction_csvs(limit_files=limit_files)
+        
+        if not predictions:
+            logger.error("No prediction data loaded. Cannot run backtest.")
+            return None, None, None
+        
+        logger.info(f"Loaded predictions for {len(predictions)} instruments")
+        
+        # Create multi-asset data
+        logger.info("Creating multi-asset data...")
+        actual_df, predicted_df = self.create_multi_asset_data(predictions)
+        
+        if actual_df.empty or predicted_df.empty:
+            logger.error("No data available for backtesting.")
+            return None, None, None
+        
+        logger.info(f"Created data with {len(actual_df)} time periods and {len(actual_df.columns)} assets")
+        
+        # Test position sizing strategies
+        logger.info("Testing position sizing strategies...")
+        results = self.test_position_sizing_strategies(actual_df, predicted_df)
+        
+        if not results:
+            logger.error("No strategy results available.")
+            return None, None, None
+        
+        # Generate performance plots
+        logger.info("Generating performance plots...")
+        plot_file, csv_file = self.generate_performance_plots(results, self.output_dir)
+        
+        # Print summary
+        logger.info("\n" + "="*80)
+        logger.info("CSV BACKTEST RESULTS SUMMARY")
+        logger.info("="*80)
+        
+        # Sort by Sharpe ratio
+        sorted_results = sorted(results.items(), key=lambda x: x[1]['sharpe_ratio'], reverse=True)
+        
+        logger.info(f"{'Strategy':<20} | {'Return':<8} | {'Sharpe':<6} | {'Max DD':<8} | {'Win Rate':<8} | {'# Trades':<8}")
+        logger.info("-" * 80)
+        
+        for name, metrics in sorted_results[:10]:  # Top 10 strategies
+            logger.info(f"{name:<20} | {metrics['total_return']:8.4f} | {metrics['sharpe_ratio']:6.3f} | {metrics['max_drawdown']:8.4f} | {metrics['win_rate']:8.1%} | {metrics['num_trades']:8d}")
+        
+        logger.info("="*80)
+        if plot_file:
+            logger.info(f"Plots saved to: {plot_file}")
+        if csv_file:
+            logger.info(f"CSV data saved to: {csv_file}")
+        
+        return results, plot_file, csv_file
+
+
+def main():
+    """
+    Main function to run the CSV-based comprehensive backtest.
+    """
+    logger.info("Starting CSV-based comprehensive backtest...")
+    
+    # Create backtester
+    backtester = CSVBacktester()
+    
+    # Run comprehensive backtest
+    results, plot_file, csv_file = backtester.run_comprehensive_backtest(limit_files=100)
+    
+    if results:
+        logger.info("CSV backtest completed successfully!")
+        return results, plot_file, csv_file
+    else:
+        logger.error("CSV backtest failed!")
+        return None, None, None
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/alpaca_cli.py
+++ b/scripts/alpaca_cli.py
@@ -61,6 +61,8 @@ def main(command: str, pair: Optional[str], side: Optional[str] = "buy"):
 
     show_account - display account summary, positions, and orders
 
+    show_forecasts - display forecast predictions for a symbol
+
     :param pair: e.g. BTCUSD
     :param command:
     :param side: buy or sell (default: buy)
@@ -83,6 +85,11 @@ def main(command: str, pair: Optional[str], side: Optional[str] = "buy"):
         close_position_at_takeprofit(pair, float(side))  # Use side param as target price
     elif command == 'show_account':
         show_account()
+    elif command == 'show_forecasts':
+        if not pair:
+            logger.error("Symbol is required for show_forecasts command")
+            return
+        show_forecasts_for_symbol(pair)
 
 
 client = StockHistoricalDataClient(ALP_KEY_ID_PROD, ALP_SECRET_KEY_PROD)
@@ -537,6 +544,16 @@ def close_position_at_takeprofit(pair: str, takeprofit_price: float, start_time=
         except Exception as e:
             logger.error(f"Failed to place takeprofit limit order: {e}")
             return False
+
+
+def show_forecasts_for_symbol(symbol: str):
+    """Display forecast predictions for a symbol, using cached data when markets are closed"""
+    try:
+        # Import here to avoid circular imports
+        from show_forecasts import show_forecasts
+        show_forecasts(symbol)
+    except Exception as e:
+        logger.error(f"Error showing forecasts for {symbol}: {e}")
 
 
 if __name__ == "__main__":

--- a/scripts/position_sizing_demo.py
+++ b/scripts/position_sizing_demo.py
@@ -1,0 +1,141 @@
+import pandas as pd
+import matplotlib.pyplot as plt
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from src.position_sizing_optimizer import (
+    top_n_expected_return_sizing,
+    backtest_position_sizing_series,
+    sharpe_ratio,
+)
+
+
+def generate_demo_data(
+    num_assets: int = 5,
+    num_days: int = 200,
+    csv_files: list[str] | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    ema_span: int | None = None,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Load real returns and naive predictions from CSV price data."""
+    if not csv_files:
+        csv_files = [str(ROOT / "WIKI-AAPL.csv")]
+
+    frames = []
+    for path in csv_files:
+        df = pd.read_csv(path, parse_dates=["Date"], index_col="Date")
+        if start_date or end_date:
+            df = df.loc[start_date:end_date]
+        returns = df["Close"].pct_change().dropna()
+        if num_days:
+            returns = returns.iloc[:num_days]
+        frames.append(returns)
+
+    base = pd.concat(frames, axis=1)
+    base.columns = [f"base_{i}" for i in range(len(frames))]
+
+    assets = []
+    for i in range(num_assets):
+        series = base.iloc[:, i % base.shape[1]]
+        assets.append(series)
+    actual = pd.concat(assets, axis=1)
+    actual.columns = [f"asset_{i}" for i in range(num_assets)]
+
+    if ema_span:
+        predicted = actual.ewm(span=ema_span, adjust=False).mean().shift(1).fillna(0)
+    else:
+        predicted = actual.shift(1).fillna(0)
+    return actual, predicted
+
+
+def run_demo(
+    n_values: list[int] | None = None,
+    leverage_values: list[float] | None = None,
+    num_assets: int = 5,
+    num_days: int = 200,
+    csv_files: list[str] | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    ema_span: int | None = None,
+    output: str = "pnl_demo.png",
+    save_csv: str | None = None,
+    risk_free_rate: float = 0.0,
+    show_plot: bool = False,
+) -> pd.DataFrame:
+    n_values = n_values or [1, 3]
+    leverage_values = leverage_values or [0.5, 1.0, 2.0]
+
+    actual, predicted = generate_demo_data(
+        num_assets=num_assets,
+        num_days=num_days,
+        csv_files=csv_files,
+        start_date=start_date,
+        end_date=end_date,
+        ema_span=ema_span,
+    )
+    pnl_curves = {}
+    for n in n_values:
+        for lev in leverage_values:
+            sizes = top_n_expected_return_sizing(predicted, n=n, leverage=lev)
+            pnl_series = backtest_position_sizing_series(
+                actual, predicted, lambda _: sizes
+            )
+            pnl_series = pnl_series - risk_free_rate / 252
+            pnl_curves[f"n{n}_lev{lev}"] = pnl_series.cumsum()
+
+    df_curves = pd.DataFrame(pnl_curves)
+    df_curves.plot(title="Cumulative pnl by sizing parameters")
+    plt.xlabel("Day")
+    plt.ylabel("PnL")
+    plt.tight_layout()
+    plt.savefig(output)
+    if show_plot:
+        plt.show()
+    print(f"Chart saved to {output}")
+    if save_csv:
+        df_curves.to_csv(save_csv, index=False)
+        print(f"PnL data saved to {save_csv}")
+
+    for col in df_curves.columns:
+        pnl_total = df_curves[col].iloc[-1]
+        sharpe = sharpe_ratio(df_curves[col].diff().fillna(0), risk_free_rate=risk_free_rate)
+        print(f"{col}: total pnl={pnl_total:.4f} sharpe={sharpe:.3f}")
+
+    return df_curves
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run position sizing demo")
+    parser.add_argument("--n", nargs="*", type=int, default=[1, 3], help="n values")
+    parser.add_argument("--lev", nargs="*", type=float, default=[0.5, 1.0, 2.0] , help="leverage values")
+    parser.add_argument("--assets", type=int, default=5, help="number of assets")
+    parser.add_argument("--days", type=int, default=200, help="number of days")
+    parser.add_argument("--csv", nargs="*", help="CSV files for historical data")
+    parser.add_argument("--start", help="start date YYYY-MM-DD")
+    parser.add_argument("--end", help="end date YYYY-MM-DD")
+    parser.add_argument("--ema-span", type=int, help="EMA span for predictions")
+    parser.add_argument("--output", default="pnl_demo.png", help="output chart file")
+    parser.add_argument("--save-csv", help="optional csv for pnl data")
+    parser.add_argument("--rf", type=float, default=0.0, help="annual risk free rate")
+    parser.add_argument("--show", action="store_true", help="display chart interactively")
+    args = parser.parse_args()
+    run_demo(
+        args.n,
+        args.lev,
+        args.assets,
+        args.days,
+        args.csv,
+        start_date=args.start,
+        end_date=args.end,
+        ema_span=args.ema_span,
+        output=args.output,
+        save_csv=args.save_csv,
+        risk_free_rate=args.rf,
+        show_plot=args.show,
+    )

--- a/show_forecasts.py
+++ b/show_forecasts.py
@@ -14,74 +14,201 @@ def show_forecasts(symbol):
     logger.remove()
     logger.add(sys.stdout, format="{time} | {level} | {message}")
 
-    # Download the latest data
-    current_time_formatted = datetime.now().strftime('%Y-%m-%d--%H-%M-%S')
-    data_df = download_daily_stock_data(current_time_formatted)
+    # Check if market is open and if symbol is crypto
+    from src.fixtures import crypto_symbols
+    is_crypto = symbol in crypto_symbols
+    market_clock = alpaca_wrapper.get_clock()
+    is_market_open = market_clock.is_open
+    
+    logger.info(f"Market status: {'OPEN' if is_market_open else 'CLOSED'}")
+    logger.info(f"Symbol {symbol} is crypto: {is_crypto}")
 
-    # Make predictions
-    predictions = make_predictions(current_time_formatted, alpaca_wrapper=alpaca_wrapper)
+    # For crypto, always try to get fresh data since crypto markets are always open
+    # For stocks, only get fresh data if market is open, otherwise use cached data
+    if is_crypto or is_market_open:
+        try:
+            # Download the latest data
+            current_time_formatted = datetime.now().strftime('%Y-%m-%d--%H-%M-%S')
+            data_df = download_daily_stock_data(current_time_formatted)
+            
+            # Make predictions
+            predictions = make_predictions(current_time_formatted, alpaca_wrapper=alpaca_wrapper)
+            
+            # Filter predictions for the given symbol
+            symbol_predictions = predictions[predictions['instrument'] == symbol]
+            
+            if not symbol_predictions.empty:
+                logger.info(f"Using fresh predictions for {symbol}")
+                display_predictions(symbol, symbol_predictions, data_df)
+                return
+            else:
+                logger.warning(f"No fresh predictions found for {symbol}, falling back to cached data")
+                
+        except Exception as e:
+            logger.error(f"Error getting fresh data: {e}")
+            logger.info("Falling back to cached predictions...")
+    else:
+        logger.info(f"Market is closed and {symbol} is not crypto, using cached data")
+    
+    # Fallback to cached predictions
+    cached_predictions = get_cached_predictions(symbol)
+    if cached_predictions is not None:
+        logger.info(f"Using cached predictions for {symbol}")
+        display_predictions(symbol, cached_predictions, None)
+    else:
+        logger.error(f"No cached predictions found for symbol {symbol}")
 
-    # Filter predictions for the given symbol
-    symbol_predictions = predictions[predictions['instrument'] == symbol]
 
-    if symbol_predictions.empty:
-        logger.error(f"No predictions found for symbol {symbol}")
-        return
+def get_cached_predictions(symbol):
+    """Get the most recent cached predictions for a symbol"""
+    results_dir = Path(__file__).parent / "results"
+    if not results_dir.exists():
+        return None
+    
+    # Get all prediction files sorted by modification time (newest first)
+    prediction_files = sorted(results_dir.glob("predictions-*.csv"), 
+                            key=lambda x: x.stat().st_mtime, reverse=True)
+    
+    # Add the generic predictions.csv file if it exists
+    generic_file = results_dir / "predictions.csv"
+    if generic_file.exists():
+        prediction_files.insert(0, generic_file)
+    
+    # Search through files to find the symbol
+    for pred_file in prediction_files:
+        try:
+            predictions = pd.read_csv(pred_file)
+            if 'instrument' in predictions.columns:
+                symbol_predictions = predictions[predictions['instrument'] == symbol]
+                if not symbol_predictions.empty:
+                    logger.info(f"Found cached predictions in {pred_file.name}")
+                    return symbol_predictions
+        except Exception as e:
+            logger.warning(f"Error reading {pred_file}: {e}")
+            continue
+    
+    return None
+
+
+def display_predictions(symbol, symbol_predictions, data_df):
+    """Display prediction results for a symbol"""
 
     # Display forecasts
     logger.info(f"Forecasts for {symbol}:")
-    logger.info(f"Close price: {symbol_predictions['close_predicted_price_value'].values[0]:.2f}")
-    logger.info(f"High price: {symbol_predictions['high_predicted_price_value'].values[0]:.2f}")
-    logger.info(f"Low price: {symbol_predictions['low_predicted_price_value'].values[0]:.2f}")
+    
+    # Handle both new and old column formats
+    close_price_col = None
+    high_price_col = None
+    low_price_col = None
+    
+    for col in symbol_predictions.columns:
+        if 'close_predicted_price' in col and 'value' in col:
+            close_price_col = col
+        elif 'high_predicted_price' in col and 'value' in col:
+            high_price_col = col
+        elif 'low_predicted_price' in col and 'value' in col:
+            low_price_col = col
+    
+    # Fallback to older column names if new ones not found
+    if close_price_col is None:
+        close_price_col = 'close_predicted_price'
+    if high_price_col is None:
+        high_price_col = 'high_predicted_price'
+    if low_price_col is None:
+        low_price_col = 'low_predicted_price'
+    
+    try:
+        if close_price_col in symbol_predictions.columns:
+            close_value = symbol_predictions[close_price_col].values[0]
+            # Handle string representations like "(119.93537139892578,)"
+            if isinstance(close_value, str) and close_value.startswith('(') and close_value.endswith(')'):
+                close_value = float(close_value.strip('()').rstrip(','))
+            logger.info(f"Close price: {close_value:.2f}")
+        
+        if high_price_col in symbol_predictions.columns:
+            high_value = symbol_predictions[high_price_col].values[0]
+            if isinstance(high_value, str) and high_value.startswith('(') and high_value.endswith(')'):
+                high_value = float(high_value.strip('()').rstrip(','))
+            logger.info(f"High price: {high_value:.2f}")
+        
+        if low_price_col in symbol_predictions.columns:
+            low_value = symbol_predictions[low_price_col].values[0]
+            if isinstance(low_value, str) and low_value.startswith('(') and low_value.endswith(')'):
+                low_value = float(low_value.strip('()').rstrip(','))
+            logger.info(f"Low price: {low_value:.2f}")
+            
+    except Exception as e:
+        logger.warning(f"Error displaying price predictions: {e}")
 
+    # Display trading strategies if available
+    strategy_cols = ['entry_takeprofit_profit', 'maxdiffprofit_profit', 'takeprofit_profit']
     logger.info("\nTrading strategies:")
-    logger.info(f"Entry TakeProfit: {symbol_predictions['entry_takeprofit_profit'].values[0]:.4f}")
-    logger.info(f"MaxDiff Profit: {symbol_predictions['maxdiffprofit_profit'].values[0]:.4f}")
-    logger.info(f"TakeProfit: {symbol_predictions['takeprofit_profit'].values[0]:.4f}")
+    for col in strategy_cols:
+        if col in symbol_predictions.columns:
+            try:
+                value = symbol_predictions[col].values[0]
+                if isinstance(value, str) and value.startswith('(') and value.endswith(')'):
+                    value = float(value.strip('()').rstrip(','))
+                logger.info(f"{col.replace('_', ' ').title()}: {value:.4f}")
+            except Exception as e:
+                logger.warning(f"Error displaying {col}: {e}")
 
     # Log all data in symbol_predictions
     logger.info("\nAll prediction data:")
     for key, value in symbol_predictions.iloc[0].to_dict().items():
-        if isinstance(value, float):
-            logger.info(f"{key}: {value:.6f}")
-        elif isinstance(value, list):
+        try:
+            if isinstance(value, str) and value.startswith('(') and value.endswith(')'):
+                # Handle string representations like "(119.93537139892578,)"
+                clean_value = float(value.strip('()').rstrip(','))
+                logger.info(f"{key}: {clean_value:.6f}")
+            elif isinstance(value, float):
+                logger.info(f"{key}: {value:.6f}")
+            elif isinstance(value, list):
+                logger.info(f"{key}: {value}")
+            else:
+                logger.info(f"{key}: {value}")
+        except Exception as e:
             logger.info(f"{key}: {value}")
-        else:
-            logger.info(f"{key}: {value}")
 
-    # Get the last timestamp from data_df
-    last_timestamp = data_df.index[-1]
-    if isinstance(last_timestamp, pd.Timestamp):
-        last_timestamp = last_timestamp.strftime('%Y-%m-%d %H:%M:%S')
-    elif isinstance(data_df.index, pd.MultiIndex):
-        last_timestamp = data_df.index.get_level_values('timestamp')[-1]
+    # Get the last timestamp from data_df (only if available)
+    if data_df is not None:
+        try:
+            last_timestamp = data_df.index[-1]
+            if isinstance(last_timestamp, pd.Timestamp):
+                last_timestamp = last_timestamp.strftime('%Y-%m-%d %H:%M:%S')
+            elif isinstance(data_df.index, pd.MultiIndex):
+                last_timestamp = data_df.index.get_level_values('timestamp')[-1]
+            else:
+                last_timestamp = data_df['timestamp'].iloc[-1] if 'timestamp' in data_df.columns else None
+
+            if last_timestamp is None:
+                logger.warning("Unable to find timestamp in the data")
+                return
+            logger.info(f"Last timestamp: {last_timestamp}")
+            
+            # Convert last_timestamp to datetime object
+            if isinstance(last_timestamp, str):
+                last_timestamp_datetime = datetime.fromisoformat(last_timestamp)
+            elif isinstance(last_timestamp, pd.Timestamp):
+                last_timestamp_datetime = last_timestamp.to_pydatetime()
+            else:
+                logger.warning(f"Unexpected timestamp type: {type(last_timestamp)}")
+                return
+
+            logger.info(f"Last timestamp datetime: {last_timestamp_datetime}")
+            
+            # Convert to NZDT
+            nzdt = pytz.timezone('Pacific/Auckland')  # NZDT timezone
+            last_timestamp_nzdt = last_timestamp_datetime.astimezone(nzdt)
+            logger.info(f"Last timestamp NZDT: {last_timestamp_nzdt}")
+            
+            # Add one day and print
+            last_timestamp_nzdt_plus_one = last_timestamp_nzdt + timedelta(days=1)
+            logger.info(f"Last timestamp NZDT plus one day: {last_timestamp_nzdt_plus_one}")
+        except Exception as e:
+            logger.warning(f"Error processing timestamp data: {e}")
     else:
-        last_timestamp = data_df['timestamp'].iloc[-1] if 'timestamp' in data_df.columns else None
-
-    if last_timestamp is None:
-        logger.warning("Unable to find timestamp in the data")
-        return
-    logger.info(f"Last timestamp: {last_timestamp}")
-    
-    # Convert last_timestamp to datetime object
-    if isinstance(last_timestamp, str):
-        last_timestamp_datetime = datetime.fromisoformat(last_timestamp)
-    elif isinstance(last_timestamp, pd.Timestamp):
-        last_timestamp_datetime = last_timestamp.to_pydatetime()
-    else:
-        logger.warning(f"Unexpected timestamp type: {type(last_timestamp)}")
-        return
-
-    logger.info(f"Last timestamp datetime: {last_timestamp_datetime}")
-    
-    # Convert to NZDT
-    nzdt = pytz.timezone('Pacific/Auckland')  # NZDT timezone
-    last_timestamp_nzdt = last_timestamp_datetime.astimezone(nzdt)
-    logger.info(f"Last timestamp NZDT: {last_timestamp_nzdt}")
-    
-    # Add one day and print
-    last_timestamp_nzdt_plus_one = last_timestamp_nzdt + timedelta(days=1)
-    logger.info(f"Last timestamp NZDT plus one day: {last_timestamp_nzdt_plus_one}")
+        logger.info("No fresh data available - using cached predictions only")
 
     # # Display historical data
     # base_dir = Path(__file__).parent

--- a/show_forecasts.py
+++ b/show_forecasts.py
@@ -45,7 +45,9 @@ def show_forecasts(symbol):
                 logger.warning(f"No fresh predictions found for {symbol}, falling back to cached data")
                 
         except Exception as e:
+            import traceback
             logger.error(f"Error getting fresh data: {e}")
+            logger.error(f"Traceback: {traceback.format_exc()}")
             logger.info("Falling back to cached predictions...")
     else:
         logger.info(f"Market is closed and {symbol} is not crypto, using cached data")

--- a/src/advanced_position_sizing.py
+++ b/src/advanced_position_sizing.py
@@ -1,0 +1,347 @@
+"""
+Advanced position sizing strategies for comprehensive backtesting.
+"""
+
+import pandas as pd
+import numpy as np
+from typing import Union, Dict, List, Optional
+from sklearn.preprocessing import StandardScaler
+import warnings
+warnings.filterwarnings('ignore')
+
+Returns = Union[pd.Series, pd.DataFrame]
+
+
+def kelly_criterion_sizing(predicted_returns: Returns, win_rate: float = 0.55, avg_win: float = 0.02, avg_loss: float = 0.01) -> Returns:
+    """
+    Kelly Criterion position sizing based on win rate and average win/loss.
+    
+    Kelly % = (bp - q) / b
+    where:
+    - b = odds (avg_win / avg_loss)
+    - p = probability of winning
+    - q = probability of losing (1 - p)
+    """
+    b = avg_win / avg_loss if avg_loss > 0 else 1
+    p = win_rate
+    q = 1 - p
+    
+    kelly_fraction = (b * p - q) / b
+    kelly_fraction = max(0, min(kelly_fraction, 1))  # Clamp between 0 and 1
+    
+    # Apply Kelly fraction to predicted returns (direction matters)
+    if isinstance(predicted_returns, pd.DataFrame):
+        sizes = predicted_returns.copy()
+        sizes[sizes > 0] = kelly_fraction
+        sizes[sizes < 0] = -kelly_fraction
+        return sizes
+    else:
+        sizes = predicted_returns.copy()
+        sizes[sizes > 0] = kelly_fraction
+        sizes[sizes < 0] = -kelly_fraction
+        return sizes
+
+
+def momentum_sizing(predicted_returns: Returns, window: int = 20, momentum_factor: float = 2.0) -> Returns:
+    """
+    Size positions based on momentum - increase size when predictions are trending in same direction.
+    """
+    if isinstance(predicted_returns, pd.DataFrame):
+        momentum_scores = predicted_returns.rolling(window=window).apply(
+            lambda x: (x > 0).sum() / len(x) if len(x) > 0 else 0.5
+        )
+        # Scale momentum: 0.5 = neutral, 1.0 = all positive, 0.0 = all negative
+        momentum_multiplier = ((momentum_scores - 0.5) * momentum_factor + 1).clip(0.1, 3.0)
+        return predicted_returns * momentum_multiplier
+    else:
+        momentum_score = predicted_returns.rolling(window=window).apply(
+            lambda x: (x > 0).sum() / len(x) if len(x) > 0 else 0.5
+        )
+        momentum_multiplier = ((momentum_score - 0.5) * momentum_factor + 1).clip(0.1, 3.0)
+        return predicted_returns * momentum_multiplier
+
+
+def regime_aware_sizing(predicted_returns: Returns, volatility_window: int = 30, vol_threshold: float = 0.02) -> Returns:
+    """
+    Adjust position sizes based on market regime (high vs low volatility).
+    """
+    if isinstance(predicted_returns, pd.DataFrame):
+        # Calculate rolling volatility for each asset
+        volatility = predicted_returns.rolling(window=volatility_window).std()
+        
+        # Create regime multiplier (reduce size in high vol regime)
+        regime_multiplier = (vol_threshold / volatility).clip(0.2, 2.0)
+        return predicted_returns * regime_multiplier
+    else:
+        volatility = predicted_returns.rolling(window=volatility_window).std()
+        regime_multiplier = (vol_threshold / volatility).clip(0.2, 2.0)
+        return predicted_returns * regime_multiplier
+
+
+def correlation_adjusted_sizing(predicted_returns: pd.DataFrame, lookback: int = 60, max_correlation: float = 0.7) -> pd.DataFrame:
+    """
+    Adjust position sizes based on correlation between assets to avoid over-concentration.
+    """
+    if not isinstance(predicted_returns, pd.DataFrame):
+        raise ValueError("correlation_adjusted_sizing requires DataFrame input")
+    
+    sizes = predicted_returns.copy()
+    
+    for i in range(lookback, len(predicted_returns)):
+        # Calculate correlation matrix for the lookback period
+        returns_window = predicted_returns.iloc[i-lookback:i]
+        corr_matrix = returns_window.corr().abs()
+        
+        # Find highly correlated pairs
+        high_corr_pairs = []
+        for col1 in corr_matrix.columns:
+            for col2 in corr_matrix.columns:
+                if col1 != col2 and corr_matrix.loc[col1, col2] > max_correlation:
+                    high_corr_pairs.append((col1, col2))
+        
+        # Reduce position sizes for highly correlated assets
+        row_sizes = sizes.iloc[i].copy()
+        for col1, col2 in high_corr_pairs:
+            # Reduce the size of the smaller position
+            if abs(row_sizes[col1]) < abs(row_sizes[col2]):
+                row_sizes[col1] *= 0.5
+            else:
+                row_sizes[col2] *= 0.5
+        
+        sizes.iloc[i] = row_sizes
+    
+    return sizes
+
+
+def adaptive_k_sizing(predicted_returns: Returns, base_k: float = 3.0, adaptation_window: int = 30) -> Returns:
+    """
+    Adaptive K-divisor that adjusts based on recent performance.
+    """
+    if isinstance(predicted_returns, pd.DataFrame):
+        # Calculate recent volatility to adjust K
+        recent_vol = predicted_returns.rolling(window=adaptation_window).std()
+        avg_vol = recent_vol.mean()
+        
+        # Adjust K based on volatility (higher vol -> higher K -> smaller positions)
+        k_adjustment = recent_vol / avg_vol
+        adaptive_k = base_k * k_adjustment
+        
+        return predicted_returns / adaptive_k
+    else:
+        recent_vol = predicted_returns.rolling(window=adaptation_window).std()
+        avg_vol = recent_vol.mean()
+        
+        k_adjustment = recent_vol / avg_vol
+        adaptive_k = base_k * k_adjustment
+        
+        return predicted_returns / adaptive_k
+
+
+def confidence_weighted_sizing(predicted_returns: Returns, confidence_scores: Optional[Returns] = None) -> Returns:
+    """
+    Weight position sizes by prediction confidence.
+    If no confidence scores provided, use absolute magnitude of predictions as proxy.
+    """
+    if confidence_scores is None:
+        # Use absolute magnitude as confidence proxy
+        confidence_scores = abs(predicted_returns)
+    
+    # Normalize confidence scores
+    if isinstance(confidence_scores, pd.DataFrame):
+        confidence_normalized = confidence_scores.div(confidence_scores.max(axis=1), axis=0).fillna(0)
+    else:
+        confidence_normalized = confidence_scores / confidence_scores.max()
+    
+    return predicted_returns * confidence_normalized
+
+
+def sector_balanced_sizing(predicted_returns: pd.DataFrame, sector_mapping: Dict[str, str], max_sector_weight: float = 0.4) -> pd.DataFrame:
+    """
+    Balance position sizes across sectors to avoid concentration risk.
+    """
+    if not isinstance(predicted_returns, pd.DataFrame):
+        raise ValueError("sector_balanced_sizing requires DataFrame input")
+    
+    sizes = predicted_returns.copy()
+    
+    for i in range(len(sizes)):
+        row_sizes = sizes.iloc[i].copy()
+        
+        # Group by sector and calculate total exposure
+        sector_exposure = {}
+        for asset, sector in sector_mapping.items():
+            if asset in row_sizes.index:
+                if sector not in sector_exposure:
+                    sector_exposure[sector] = 0
+                sector_exposure[sector] += abs(row_sizes[asset])
+        
+        # Calculate total exposure
+        total_exposure = sum(sector_exposure.values())
+        
+        # Adjust sizes if any sector is over-weighted
+        for sector, exposure in sector_exposure.items():
+            if exposure > max_sector_weight * total_exposure:
+                # Scale down all assets in this sector
+                sector_assets = [asset for asset, s in sector_mapping.items() if s == sector and asset in row_sizes.index]
+                scale_factor = (max_sector_weight * total_exposure) / exposure
+                for asset in sector_assets:
+                    row_sizes[asset] *= scale_factor
+        
+        sizes.iloc[i] = row_sizes
+    
+    return sizes
+
+
+def risk_parity_sizing(predicted_returns: pd.DataFrame, lookback: int = 60) -> pd.DataFrame:
+    """
+    Risk parity position sizing - equal risk contribution from each asset.
+    """
+    if not isinstance(predicted_returns, pd.DataFrame):
+        raise ValueError("risk_parity_sizing requires DataFrame input")
+    
+    sizes = predicted_returns.copy()
+    
+    for i in range(lookback, len(predicted_returns)):
+        # Calculate covariance matrix for the lookback period
+        returns_window = predicted_returns.iloc[i-lookback:i]
+        cov_matrix = returns_window.cov()
+        
+        # Calculate inverse volatility weights
+        volatilities = np.sqrt(np.diag(cov_matrix))
+        inv_vol_weights = 1 / volatilities
+        inv_vol_weights = inv_vol_weights / inv_vol_weights.sum()
+        
+        # Apply weights to predicted returns (maintaining direction)
+        row_predictions = predicted_returns.iloc[i]
+        row_sizes = row_predictions.copy()
+        
+        for j, asset in enumerate(row_sizes.index):
+            if row_predictions[asset] != 0:
+                row_sizes[asset] = np.sign(row_predictions[asset]) * inv_vol_weights[j]
+        
+        sizes.iloc[i] = row_sizes
+    
+    return sizes
+
+
+def machine_learning_sizing(predicted_returns: pd.DataFrame, lookback: int = 100) -> pd.DataFrame:
+    """
+    Use simple ML approach to determine optimal position sizes based on historical performance.
+    """
+    if not isinstance(predicted_returns, pd.DataFrame):
+        raise ValueError("machine_learning_sizing requires DataFrame input")
+    
+    sizes = predicted_returns.copy()
+    
+    # Simple approach: use correlation between prediction magnitude and next period return
+    for i in range(lookback, len(predicted_returns)):
+        # Historical data
+        hist_predictions = predicted_returns.iloc[i-lookback:i]
+        hist_returns = predicted_returns.iloc[i-lookback+1:i+1]  # Next period returns
+        
+        # Calculate correlation between prediction magnitude and actual returns
+        correlation_scores = {}
+        for asset in hist_predictions.columns:
+            if asset in hist_returns.columns:
+                corr = np.corrcoef(abs(hist_predictions[asset]), abs(hist_returns[asset]))[0, 1]
+                correlation_scores[asset] = corr if not np.isnan(corr) else 0
+        
+        # Use correlation as confidence multiplier
+        row_predictions = predicted_returns.iloc[i]
+        row_sizes = row_predictions.copy()
+        
+        for asset in row_sizes.index:
+            if asset in correlation_scores:
+                confidence = max(0, correlation_scores[asset])  # Only positive correlations
+                row_sizes[asset] *= confidence
+        
+        sizes.iloc[i] = row_sizes
+    
+    return sizes
+
+
+def multi_timeframe_sizing(predicted_returns: pd.DataFrame, short_window: int = 5, long_window: int = 20) -> pd.DataFrame:
+    """
+    Combine short-term and long-term predictions for position sizing.
+    """
+    if not isinstance(predicted_returns, pd.DataFrame):
+        raise ValueError("multi_timeframe_sizing requires DataFrame input")
+    
+    # Calculate short-term and long-term moving averages of predictions
+    short_ma = predicted_returns.rolling(window=short_window).mean()
+    long_ma = predicted_returns.rolling(window=long_window).mean()
+    
+    # Combine signals: stronger when both timeframes agree
+    combined_signal = predicted_returns.copy()
+    
+    # Boost signal when short and long term agree
+    agreement_boost = np.sign(short_ma) * np.sign(long_ma)  # 1 when same direction, -1 when opposite
+    combined_signal = combined_signal * (1 + 0.5 * agreement_boost)
+    
+    return combined_signal
+
+
+def get_all_advanced_strategies() -> Dict[str, callable]:
+    """
+    Get dictionary of all advanced position sizing strategies.
+    """
+    return {
+        'kelly_criterion': lambda p: kelly_criterion_sizing(p),
+        'momentum_20d': lambda p: momentum_sizing(p, window=20, momentum_factor=2.0),
+        'momentum_10d': lambda p: momentum_sizing(p, window=10, momentum_factor=1.5),
+        'regime_aware': lambda p: regime_aware_sizing(p),
+        'adaptive_k3': lambda p: adaptive_k_sizing(p, base_k=3.0),
+        'adaptive_k5': lambda p: adaptive_k_sizing(p, base_k=5.0),
+        'confidence_weighted': lambda p: confidence_weighted_sizing(p),
+        'multi_timeframe': lambda p: multi_timeframe_sizing(p) if isinstance(p, pd.DataFrame) else p,
+    }
+
+
+def get_dataframe_only_strategies() -> Dict[str, callable]:
+    """
+    Get strategies that only work with DataFrame inputs (multi-asset).
+    """
+    return {
+        'risk_parity': lambda p: risk_parity_sizing(p),
+        'ml_sizing': lambda p: machine_learning_sizing(p),
+        'correlation_adjusted': lambda p: correlation_adjusted_sizing(p),
+    }
+
+
+if __name__ == "__main__":
+    # Example usage
+    import matplotlib.pyplot as plt
+    
+    # Create sample data
+    np.random.seed(42)
+    dates = pd.date_range('2023-01-01', periods=100, freq='D')
+    n_assets = 5
+    
+    # Generate correlated returns
+    returns = np.random.randn(100, n_assets) * 0.02
+    returns = pd.DataFrame(returns, index=dates, columns=[f'Asset_{i}' for i in range(n_assets)])
+    
+    # Generate predictions (slightly correlated with future returns)
+    predictions = returns.shift(1).fillna(0) + np.random.randn(100, n_assets) * 0.01
+    
+    # Test different strategies
+    strategies = get_all_advanced_strategies()
+    
+    fig, axes = plt.subplots(2, 2, figsize=(15, 10))
+    axes = axes.flatten()
+    
+    for i, (name, strategy_func) in enumerate(list(strategies.items())[:4]):
+        try:
+            sizes = strategy_func(predictions)
+            cumulative_pnl = (sizes * returns).sum(axis=1).cumsum()
+            axes[i].plot(cumulative_pnl)
+            axes[i].set_title(f'{name} Strategy')
+            axes[i].grid(True)
+        except Exception as e:
+            print(f"Error with {name}: {e}")
+    
+    plt.tight_layout()
+    plt.savefig('advanced_strategies_demo.png')
+    plt.show()
+    
+    print("Advanced position sizing strategies demo completed!")

--- a/src/forecasting_bolt_wrapper.py
+++ b/src/forecasting_bolt_wrapper.py
@@ -1,0 +1,72 @@
+import torch
+import numpy as np
+from chronos import BaseChronosPipeline
+
+class ForecastingBoltWrapper:
+    def __init__(self, model_name="amazon/chronos-bolt-base", device="cuda"):
+        self.model_name = model_name
+        self.device = device
+        self.pipeline = None
+    
+    def load_pipeline(self):
+        if self.pipeline is None:
+            self.pipeline = BaseChronosPipeline.from_pretrained(
+                self.model_name,
+                device_map=self.device,
+            )
+            self.pipeline.model = self.pipeline.model.eval()
+    
+    def predict_sequence(self, context_data, prediction_length=7):
+        """
+        Make predictions for a sequence of steps
+        
+        Args:
+            context_data: torch.Tensor or array-like data for context
+            prediction_length: int, number of predictions to make
+            
+        Returns:
+            list of predictions
+        """
+        self.load_pipeline()
+        
+        if not isinstance(context_data, torch.Tensor):
+            context_data = torch.tensor(context_data, dtype=torch.float)
+        
+        predictions = []
+        
+        for pred_idx in reversed(range(1, prediction_length + 1)):
+            current_context = context_data[:-pred_idx] if pred_idx > 1 else context_data
+            
+            forecast = self.pipeline.predict(
+                current_context,
+                prediction_length=1,
+            )
+            
+            low, median, high = np.quantile(forecast[0].numpy(), [0.1, 0.5, 0.9], axis=0)
+            predictions.append(median.item())
+        
+        return predictions
+    
+    def predict_single(self, context_data, prediction_length=1):
+        """
+        Make a single prediction
+        
+        Args:
+            context_data: torch.Tensor or array-like data for context
+            prediction_length: int, prediction horizon
+            
+        Returns:
+            median prediction value
+        """
+        self.load_pipeline()
+        
+        if not isinstance(context_data, torch.Tensor):
+            context_data = torch.tensor(context_data, dtype=torch.float)
+        
+        forecast = self.pipeline.predict(
+            context_data,
+            prediction_length,
+        )
+        
+        low, median, high = np.quantile(forecast[0].numpy(), [0.1, 0.5, 0.9], axis=0)
+        return median.item() if prediction_length == 1 else median

--- a/src/models/toto_wrapper.py
+++ b/src/models/toto_wrapper.py
@@ -1,0 +1,165 @@
+"""
+Toto forecasting wrapper to replace Chronos
+"""
+import torch
+import numpy as np
+from pathlib import Path
+from typing import Union, List, Optional, Tuple
+from dataclasses import dataclass
+import sys
+# need to uv pip install -e . in here after dl toto
+sys.path.insert(0, '/mnt/fast/code/chronos-forecasting/toto')
+
+from toto.data.util.dataset import MaskedTimeseries
+from toto.inference.forecaster import TotoForecaster
+from toto.model.toto import Toto
+
+
+@dataclass
+class TotoForecast:
+    """Container for Toto forecast results - compatible with Chronos format"""
+    samples: np.ndarray
+    
+    def numpy(self):
+        """Return numpy array of samples in Chronos-compatible format"""
+        # Toto returns shape (1, num_variables, prediction_length, num_samples)
+        # We need to reshape to match Chronos format
+        samples = self.samples
+        
+        # Remove batch dimension if present (first dim = 1)
+        if samples.ndim == 4 and samples.shape[0] == 1:
+            samples = samples.squeeze(0)  # Now (num_variables, prediction_length, num_samples)
+        
+        # Remove variable dimension if single variable (first dim = 1)
+        if samples.ndim == 3 and samples.shape[0] == 1:
+            samples = samples.squeeze(0)  # Now (prediction_length, num_samples)
+        
+        # For single prediction step, return 1D array of samples
+        if samples.ndim == 2 and samples.shape[0] == 1:
+            return samples.squeeze(0)  # Shape (num_samples,)
+        
+        # For multiple prediction steps, transpose to (num_samples, prediction_length)
+        if samples.ndim == 2:
+            return samples.T
+        
+        return samples
+
+
+class TotoPipeline:
+    """
+    Wrapper class that mimics ChronosPipeline interface for Toto model
+    """
+    
+    def __init__(self, model: Toto, device: str = 'cuda'):
+        self.device = device
+        self.model = model.to(device)
+        self.model.eval()
+        
+        # Optionally compile for speed
+        try:
+            self.model.compile()
+        except Exception as e:
+            print(f"Could not compile model: {e}")
+            
+        self.forecaster = TotoForecaster(self.model.model)
+        
+    @classmethod
+    def from_pretrained(
+        cls, 
+        model_id: str = "Datadog/Toto-Open-Base-1.0",
+        device_map: str = "cuda",
+        torch_dtype: Optional[torch.dtype] = None,
+        **kwargs
+    ):
+        """
+        Load pretrained Toto model
+        
+        Args:
+            model_id: Model identifier (default: Datadog/Toto-Open-Base-1.0)
+            device_map: Device to load model on
+            torch_dtype: Data type for model (ignored for compatibility)
+            **kwargs: Additional arguments (ignored)
+            
+        Returns:
+            TotoPipeline instance
+        """
+        device = device_map if device_map != "mps" else "cpu"  # MPS not fully supported
+        
+        # Load pre-trained Toto model
+        model = Toto.from_pretrained(model_id)
+        
+        return cls(model, device)
+    
+    def predict(
+        self,
+        context: Union[torch.Tensor, np.ndarray, List[float]],
+        prediction_length: int,
+        num_samples: int = 2048,
+        temperature: float = 1.0,
+        top_k: Optional[int] = None,
+        top_p: Optional[float] = None,
+        **kwargs
+    ) -> List[TotoForecast]:
+        """
+        Generate forecasts using Toto model
+        
+        Args:
+            context: Historical time series data
+            prediction_length: Number of steps to forecast
+            num_samples: Number of sample paths to generate
+            temperature: Sampling temperature (ignored, for compatibility)
+            top_k: Top-k sampling (ignored, for compatibility)
+            top_p: Top-p sampling (ignored, for compatibility)
+            
+        Returns:
+            List containing single TotoForecast object
+        """
+        # Convert context to tensor if needed
+        if isinstance(context, (list, np.ndarray)):
+            context = torch.tensor(context, dtype=torch.float32)
+            
+        # Move to device
+        context = context.to(self.device)
+        
+        # Ensure 2D shape (variables x timesteps)
+        if context.dim() == 1:
+            context = context.unsqueeze(0)  # Add variable dimension
+            
+        # Get context length
+        seq_len = context.shape[-1]
+        
+        # Create timestamps (assuming regular intervals)
+        # Using 15-minute intervals as default (can be adjusted)
+        time_interval_seconds = 60 * 15  # 15 minutes
+        timestamp_seconds = torch.zeros(1, seq_len).to(self.device)
+        time_interval_tensor = torch.full((1,), time_interval_seconds).to(self.device)
+        
+        # Create MaskedTimeseries input
+        inputs = MaskedTimeseries(
+            series=context,
+            padding_mask=torch.full_like(context, True, dtype=torch.bool),
+            id_mask=torch.zeros_like(context),
+            timestamp_seconds=timestamp_seconds,
+            time_interval_seconds=time_interval_tensor,
+        )
+        
+        # Generate forecasts
+        # Note: Toto generates multiple samples at once
+        with torch.inference_mode():
+            forecast = self.forecaster.forecast(
+                inputs,
+                prediction_length=prediction_length,
+                num_samples=num_samples,
+                samples_per_batch=256,  # Batch size for memory efficiency
+            )
+        
+        # Convert to numpy and reshape to match Chronos output format
+        # Chronos returns shape: (num_samples, prediction_length)
+        samples = forecast.samples.cpu().numpy()
+        
+        # If samples has shape (1, num_samples, prediction_length), squeeze first dim
+        if samples.ndim == 3 and samples.shape[0] == 1:
+            samples = samples.squeeze(0)
+            
+        # Return as list with single forecast (matching Chronos interface)
+        return [TotoForecast(samples=samples)]

--- a/src/position_sizing_optimizer.py
+++ b/src/position_sizing_optimizer.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import numpy as np
-from typing import Callable, Dict, Union
+from typing import Callable, Dict, Union, Optional
 
 
 Returns = Union[pd.Series, pd.DataFrame]
@@ -87,7 +87,7 @@ def optimize_position_sizing(
     predicted_returns: Returns,
     trading_fee: float = 0.0,
     risk_factor: float = 1.0,
-    max_abs_size: float | None = None,
+    max_abs_size: Optional[float] = None,
     risk_free_rate: float = 0.0,
 ) -> Dict[str, float]:
     """Return pnl and Sharpe ratio for several sizing strategies."""

--- a/src/position_sizing_optimizer.py
+++ b/src/position_sizing_optimizer.py
@@ -1,0 +1,130 @@
+import pandas as pd
+import numpy as np
+from typing import Callable, Dict, Union
+
+
+Returns = Union[pd.Series, pd.DataFrame]
+
+
+def constant_sizing(predicted_returns: Returns, factor: float = 1.0) -> Returns:
+    """Return a constant position size for each input element."""
+    if isinstance(predicted_returns, pd.DataFrame):
+        return pd.DataFrame(
+            factor, index=predicted_returns.index, columns=predicted_returns.columns
+        )
+    return pd.Series(factor, index=predicted_returns.index)
+
+
+def expected_return_sizing(predicted_returns: Returns, risk_factor: float = 1.0) -> Returns:
+    """Size positions proportional to the predicted return."""
+    return predicted_returns.fillna(0.0) * risk_factor
+
+
+def volatility_scaled_sizing(predicted_returns: Returns, window: int = 5) -> Returns:
+    """Scale position size by the rolling standard deviation of predictions."""
+    vol = predicted_returns.abs().rolling(window=window, min_periods=1).std()
+    if isinstance(vol, pd.DataFrame):
+        fill_value = vol.mean().replace(0.0, np.nan).fillna(1.0)
+        vol = vol.replace(0.0, np.nan).fillna(fill_value)
+    else:
+        vol = vol.replace(0.0, np.nan).fillna(vol.mean() or 1.0)
+    return predicted_returns / vol
+
+
+def top_n_expected_return_sizing(
+    predicted_returns: pd.DataFrame, n: int, leverage: float = 1.0
+) -> pd.DataFrame:
+    """Allocate leverage equally across the top ``n`` positive predictions."""
+    if not isinstance(predicted_returns, pd.DataFrame):
+        raise TypeError("predicted_returns must be a DataFrame for top-n sizing")
+
+    positive = predicted_returns.clip(lower=0)
+    ranks = positive.rank(axis=1, ascending=False, method="first")
+    selected = ranks.le(n)
+    counts = selected.sum(axis=1).replace(0, np.nan)
+    sizes = selected.div(counts, axis=0).fillna(0.0) * leverage
+    return sizes
+
+
+def sharpe_ratio(pnl_series: pd.Series, periods_per_year: int = 252, risk_free_rate: float = 0.0) -> float:
+    """Compute the annualised Sharpe ratio of a pnl series."""
+    excess = pnl_series - risk_free_rate / periods_per_year
+    denominator = pnl_series.std(ddof=0) or 1e-9
+    return np.sqrt(periods_per_year) * excess.mean() / denominator
+
+
+def backtest_position_sizing_series(
+    actual_returns: Returns,
+    predicted_returns: Returns,
+    sizing_func: Callable[[Returns], Returns],
+    trading_fee: float = 0.0,
+) -> pd.Series:
+    """Return a pnl series for the provided sizing strategy."""
+    sizes = sizing_func(predicted_returns)
+    if isinstance(actual_returns, pd.DataFrame):
+        pnl_series = (sizes * actual_returns).sum(axis=1) - sizes.abs().sum(axis=1) * trading_fee
+    else:
+        pnl_series = sizes * actual_returns - sizes.abs() * trading_fee
+    return pnl_series
+
+
+def backtest_position_sizing(
+    actual_returns: Returns,
+    predicted_returns: Returns,
+    sizing_func: Callable[[Returns], Returns],
+    trading_fee: float = 0.0,
+) -> float:
+    """Calculate total pnl for a given sizing strategy."""
+    pnl_series = backtest_position_sizing_series(
+        actual_returns, predicted_returns, sizing_func, trading_fee
+    )
+    pnl = float(pnl_series.sum())
+    return pnl
+
+
+def optimize_position_sizing(
+    actual_returns: Returns,
+    predicted_returns: Returns,
+    trading_fee: float = 0.0,
+    risk_factor: float = 1.0,
+    max_abs_size: float | None = None,
+    risk_free_rate: float = 0.0,
+) -> Dict[str, float]:
+    """Return pnl and Sharpe ratio for several sizing strategies."""
+    strategies: Dict[str, Callable[[Returns], Returns]] = {
+        "constant": lambda p: constant_sizing(p, factor=risk_factor),
+        "expected_return": lambda p: expected_return_sizing(p, risk_factor=risk_factor),
+        "vol_scaled": volatility_scaled_sizing,
+    }
+    results: Dict[str, float] = {}
+    for name, fn in strategies.items():
+        sizes = fn(predicted_returns)
+        if max_abs_size is not None:
+            sizes = sizes.clip(-max_abs_size, max_abs_size)
+        pnl_series = backtest_position_sizing_series(
+            actual_returns,
+            predicted_returns,
+            lambda _: sizes,
+            trading_fee,
+        )
+        results[name] = pnl_series.sum()
+        results[f"{name}_sharpe"] = sharpe_ratio(pnl_series, risk_free_rate=risk_free_rate)
+    
+    return results
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run position sizing optimizer")
+    parser.add_argument("csv", help="CSV file with a Close column")
+    parser.add_argument("--risk-free-rate", type=float, default=0.0, help="annual risk free rate")
+    args = parser.parse_args()
+
+    df = pd.read_csv(args.csv)
+    returns = df["Close"].pct_change().dropna()
+    predicted_returns = returns.shift(1).fillna(0.0)
+
+    results = optimize_position_sizing(returns, predicted_returns, risk_free_rate=args.risk_free_rate)
+    for key, val in results.items():
+        print(f"{key}: {val:.4f}")

--- a/test_chronos_bolt_fix.py
+++ b/test_chronos_bolt_fix.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""
+Test script to verify that the ChronosBoltPipeline fix works
+"""
+import torch
+import numpy as np
+from chronos import BaseChronosPipeline
+
+
+def test_chronos_bolt_fix():
+    """Test that demonstrates the fix for ChronosBoltPipeline.predict"""
+    
+    # Load the Chronos Bolt pipeline (this creates a ChronosBoltPipeline)
+    pipeline = BaseChronosPipeline.from_pretrained(
+        "amazon/chronos-bolt-base",
+        device_map="cuda",
+    )
+    
+    # Create test context data
+    context = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0], dtype=torch.float32)
+    prediction_length = 1
+    
+    print(f"Pipeline type: {type(pipeline)}")
+    print(f"Pipeline class name: {pipeline.__class__.__name__}")
+    
+    # Test the fixed predict call (should work now)
+    print("\nTest: Calling predict with only supported parameters...")
+    try:
+        forecast = pipeline.predict(
+            context,
+            prediction_length,
+        )
+        print(f"✓ Success! Forecast shape: {forecast[0].numpy().shape}")
+        
+        # Process the forecast the same way as the original code
+        low, median, high = np.quantile(forecast[0].numpy(), [0.1, 0.5, 0.9], axis=0)
+        print(f"✓ Successfully processed forecast: low={low}, median={median}, high={high}")
+        
+        # Check that we can get the median value as item (as done in original code)
+        prediction_value = median.item()
+        print(f"✓ Extracted prediction value: {prediction_value}")
+        
+    except Exception as e:
+        print(f"✗ Failed: {e}")
+        return False
+    
+    return True
+
+
+if __name__ == "__main__":
+    success = test_chronos_bolt_fix()
+    if success:
+        print("\n✓ All tests passed! The fix should work.")
+    else:
+        print("\n✗ Tests failed!")

--- a/test_chronos_bolt_pipeline.py
+++ b/test_chronos_bolt_pipeline.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""
+Test script to reproduce the ChronosBoltPipeline.predict unexpected num_samples error
+"""
+import torch
+import numpy as np
+from chronos import BaseChronosPipeline
+
+
+def test_chronos_bolt_pipeline():
+    """Test that demonstrates the num_samples parameter issue with ChronosBoltPipeline"""
+    
+    # Load the Chronos Bolt pipeline (this creates a ChronosBoltPipeline)
+    pipeline = BaseChronosPipeline.from_pretrained(
+        "amazon/chronos-bolt-base",
+        device_map="cuda",
+    )
+    
+    # Create test context data
+    context = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0], dtype=torch.float32)
+    prediction_length = 3
+    
+    print(f"Pipeline type: {type(pipeline)}")
+    print(f"Pipeline class name: {pipeline.__class__.__name__}")
+    
+    # Test 1: Call predict without num_samples (should work)
+    print("\nTest 1: Calling predict without num_samples...")
+    try:
+        forecast1 = pipeline.predict(context, prediction_length)
+        print(f"✓ Success! Forecast shape: {forecast1[0].numpy().shape}")
+    except Exception as e:
+        print(f"✗ Failed: {e}")
+    
+    # Test 2: Call predict with num_samples (should fail)
+    print("\nTest 2: Calling predict with num_samples=20...")
+    try:
+        forecast2 = pipeline.predict(
+            context,
+            prediction_length,
+            num_samples=20,
+            temperature=1.0,
+            top_k=4000,
+            top_p=1.0,
+        )
+        print(f"✓ Success! Forecast shape: {forecast2[0].numpy().shape}")
+    except Exception as e:
+        print(f"✗ Failed: {e}")
+        
+    # Test 3: Check what parameters the predict method actually accepts
+    print("\nTest 3: Checking predict method signature...")
+    import inspect
+    sig = inspect.signature(pipeline.predict)
+    print(f"Predict method parameters: {list(sig.parameters.keys())}")
+
+
+if __name__ == "__main__":
+    test_chronos_bolt_pipeline()

--- a/test_forecasting_bolt_wrapper.py
+++ b/test_forecasting_bolt_wrapper.py
@@ -1,0 +1,25 @@
+import torch
+import numpy as np
+from src.forecasting_bolt_wrapper import ForecastingBoltWrapper
+
+def test_simple_sequence():
+    """Test with simple increasing sequence: 2, 4, 6, 8, 10 -> should predict ~12"""
+    wrapper = ForecastingBoltWrapper()
+    
+    # Simple test sequence
+    test_data = torch.tensor([2.0, 4.0, 6.0, 8.0, 10.0], dtype=torch.float)
+    
+    # Single prediction
+    prediction = wrapper.predict_single(test_data, prediction_length=1)
+    print(f"Input sequence: {test_data.tolist()}")
+    print(f"Single prediction: {prediction}")
+    print(f"Expected ~12, got {prediction}")
+    
+    # Sequence predictions
+    predictions = wrapper.predict_sequence(test_data, prediction_length=3)
+    print(f"Sequence predictions (3 steps): {predictions}")
+    
+    return prediction, predictions
+
+if __name__ == "__main__":
+    test_simple_sequence()

--- a/test_toto_real_data.py
+++ b/test_toto_real_data.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""
+Realistic hyperparameter optimization test using AAPL stock data.
+Tests the Toto model's ability to predict the next Close price using historical data.
+"""
+
+import numpy as np
+import pandas as pd
+import torch
+from src.models.toto_wrapper import TotoPipeline
+from pathlib import Path
+
+def test_real_stock_prediction():
+    """Test Toto model with real AAPL stock data"""
+    
+    # Load AAPL data
+    data_file = Path("/home/lee/code/stock/data/2023-07-08 01:30:11/AAPL-2023-07-08.csv")
+    df = pd.read_csv(data_file)
+    
+    # Extract Close prices
+    close_prices = df['Close'].values
+    print(f"Loaded {len(close_prices)} AAPL Close prices")
+    print(f"Price range: ${close_prices.min():.2f} - ${close_prices.max():.2f}")
+    
+    # Use all but last price as context, predict the last price
+    context = close_prices[:-1]  # All except last
+    actual_next = close_prices[-1]  # Last price to predict
+    
+    print(f"Context: Last 5 prices: {context[-5:]}")
+    print(f"Actual next price: ${actual_next:.2f}")
+    
+    # Test different num_samples values
+    pipeline = TotoPipeline.from_pretrained('Datadog/Toto-Open-Base-1.0', device_map='cuda')
+    
+    results = []
+    
+    for num_samples in [1024, 2048, 3072, 4096]:
+        print(f"\nTesting num_samples={num_samples}:")
+        
+        # Run multiple predictions to test consistency
+        predictions = []
+        errors = []
+        
+        for run in range(3):
+            forecasts = pipeline.predict(
+                context=context.tolist(),
+                prediction_length=1,
+                num_samples=num_samples
+            )
+            
+            predicted_values = forecasts[0].numpy()
+            mean_pred = np.mean(predicted_values)
+            predictions.append(mean_pred)
+            
+            # Calculate percentage error
+            error = abs(mean_pred - actual_next) / actual_next * 100
+            errors.append(error)
+            
+            print(f"  Run {run+1}: Predicted=${mean_pred:.2f}, Error={error:.2f}%")
+        
+        # Calculate averages
+        avg_prediction = np.mean(predictions)
+        avg_error = np.mean(errors)
+        std_error = np.std(errors)
+        
+        print(f"  Average: Predicted=${avg_prediction:.2f}, Error={avg_error:.2f}% (±{std_error:.2f}%)")
+        
+        results.append({
+            'num_samples': num_samples,
+            'avg_prediction': avg_prediction,
+            'avg_error': avg_error,
+            'std_error': std_error,
+            'predictions': predictions
+        })
+    
+    # Find best configuration
+    best_result = min(results, key=lambda x: x['avg_error'])
+    
+    print(f"\n{'='*60}")
+    print("RESULTS SUMMARY:")
+    print(f"{'='*60}")
+    print(f"Actual next Close price: ${actual_next:.2f}")
+    print()
+    
+    for result in results:
+        status = "✅ BEST" if result == best_result else ""
+        print(f"num_samples={result['num_samples']:4d}: "
+              f"Pred=${result['avg_prediction']:6.2f}, "
+              f"Error={result['avg_error']:5.2f}% (±{result['std_error']:4.2f}%) {status}")
+    
+    print(f"\nBest configuration: num_samples={best_result['num_samples']} "
+          f"with {best_result['avg_error']:.2f}% average error")
+    
+    return best_result
+
+if __name__ == "__main__":
+    print("Testing Toto wrapper with real AAPL stock data...")
+    test_real_stock_prediction()

--- a/test_toto_wrapper.py
+++ b/test_toto_wrapper.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""
+Test script for toto_wrapper.py
+Tests the model with sequence 2, 4, 6, 8, 10 -> should predict ~12
+"""
+
+import numpy as np
+import torch
+from src.models.toto_wrapper import TotoPipeline
+
+def test_arithmetic_sequence():
+    """Test Toto model with arithmetic sequence 2, 4, 6, 8, 10 -> 12"""
+    
+    # Input sequence: 2, 4, 6, 8, 10
+    context = [2.0, 4.0, 6.0, 8.0, 10.0]
+    
+    print(f"Input sequence: {context}")
+    print("Expected next value: ~12")
+    
+    try:
+        # Load the Toto model
+        print("\nLoading Toto model...")
+        pipeline = TotoPipeline.from_pretrained()
+        
+        # Generate forecast for 1 step
+        print("Generating forecast...")
+        forecasts = pipeline.predict(
+            context=context,
+            prediction_length=1,
+            num_samples=3072  # Optimal samples for best accuracy
+        )
+        
+        # Get predictions
+        samples = forecasts[0].numpy()  # Shape: (num_samples,) for prediction_length=1
+        predicted_values = samples  # Already 1D array for single prediction step
+        
+        # Calculate statistics
+        mean_pred = np.mean(predicted_values)
+        median_pred = np.median(predicted_values)
+        std_pred = np.std(predicted_values)
+        
+        print(f"\nResults:")
+        print(f"Mean prediction: {mean_pred:.2f}")
+        print(f"Median prediction: {median_pred:.2f}")
+        print(f"Standard deviation: {std_pred:.2f}")
+        print(f"Min prediction: {np.min(predicted_values):.2f}")
+        print(f"Max prediction: {np.max(predicted_values):.2f}")
+        
+        # Check if prediction is close to expected value (12)
+        expected = 12.0
+        error = abs(mean_pred - expected)
+        print(f"\nExpected: {expected}")
+        print(f"Prediction error: {error:.2f}")
+        
+        if error < 2.0:  # Within 2 units
+            print("✅ Test PASSED - Prediction is close to expected value")
+        else:
+            print("❌ Test FAILED - Prediction is far from expected value")
+            
+        return mean_pred, error < 2.0
+        
+    except Exception as e:
+        print(f"❌ Test FAILED with error: {e}")
+        return None, False
+
+if __name__ == "__main__":
+    print("Testing Toto wrapper with arithmetic sequence...")
+    test_arithmetic_sequence()

--- a/tests/test_position_sizing_demo.py
+++ b/tests/test_position_sizing_demo.py
@@ -1,0 +1,19 @@
+import pandas as pd
+from scripts.position_sizing_demo import generate_demo_data, run_demo
+
+
+def test_generate_demo_data_shapes():
+    csv = ["WIKI-AAPL.csv"]
+    actual, predicted = generate_demo_data(num_assets=3, num_days=50, csv_files=csv, ema_span=3)
+    assert isinstance(actual, pd.DataFrame)
+    assert isinstance(predicted, pd.DataFrame)
+    assert actual.shape == (50, 3)
+    assert predicted.shape == (50, 3)
+
+
+def test_run_demo_returns_dataframe(tmp_path):
+    csv = ["WIKI-AAPL.csv"]
+    out = tmp_path / "chart.png"
+    df = run_demo(n_values=[1], leverage_values=[1.0], num_assets=2, num_days=30, csv_files=csv, output=str(out), show_plot=False)
+    assert isinstance(df, pd.DataFrame)
+    assert not df.empty

--- a/tests/test_position_sizing_optimizer.py
+++ b/tests/test_position_sizing_optimizer.py
@@ -1,0 +1,85 @@
+import pandas as pd
+from src.position_sizing_optimizer import (
+    constant_sizing,
+    expected_return_sizing,
+    volatility_scaled_sizing,
+    backtest_position_sizing,
+    optimize_position_sizing,
+    top_n_expected_return_sizing,
+    backtest_position_sizing_series,
+)
+
+
+def test_constant_sizing():
+    preds = pd.Series([0.1, 0.2, 0.3])
+    result = constant_sizing(preds, factor=2)
+    assert (result == 2).all()
+
+
+def test_constant_sizing_dataframe():
+    preds = pd.DataFrame({"a": [0.1, 0.2], "b": [0.3, -0.1]})
+    result = constant_sizing(preds, factor=1.5)
+    assert result.shape == preds.shape
+    assert (result == 1.5).all().all()
+
+
+def test_optimize_position_sizing():
+    actual = pd.Series([0.01, 0.02, -0.01, 0.03, -0.04])
+    preds = pd.Series([0.5, 0.3, -0.1, 0.7, -0.2])
+    results = optimize_position_sizing(actual, preds, trading_fee=0.001, risk_factor=1.0)
+    # expected_return and vol_scaled should outperform constant
+    assert results["expected_return"] > results["constant"]
+    assert results["vol_scaled"] > results["constant"]
+    # vol_scaled should also outperform expected_return for this data
+    assert results["vol_scaled"] > results["expected_return"]
+
+
+def test_risk_factor_and_clipping():
+    actual = pd.Series([0.02, 0.01])
+    preds = pd.Series([0.5, 0.6])
+    results_low = optimize_position_sizing(actual, preds, risk_factor=0.5)
+    results_high = optimize_position_sizing(actual, preds, risk_factor=2.0, max_abs_size=0.5)
+    # Risk factor increases sizing but clipping limits the effect
+    assert results_high["expected_return"] >= results_low["expected_return"]
+
+
+def test_top_n_expected_return_sizing():
+    preds = pd.DataFrame(
+        {
+            "asset1": [0.2, -0.1, 0.3],
+            "asset2": [0.1, 0.4, -0.2],
+            "asset3": [-0.05, 0.2, 0.1],
+        }
+    )
+    sizes = top_n_expected_return_sizing(preds, n=2, leverage=1.0)
+    # At each row no more than two non-zero positions
+    assert (sizes.gt(0).sum(axis=1) <= 2).all()
+    # Allocation per row sums to 1 when there is at least one positive prediction
+    sums = sizes.sum(axis=1)
+    assert sums.iloc[0] == 1.0
+    assert sums.iloc[1] == 1.0
+
+
+def test_backtest_position_sizing_series_dataframe():
+    actual = pd.DataFrame({"a": [0.01, -0.02], "b": [0.03, 0.04]})
+    predicted = actual.shift(1).fillna(0)
+    sizes = constant_sizing(predicted, factor=1.0)
+    pnl = backtest_position_sizing_series(actual, predicted, lambda _: sizes)
+    assert isinstance(pnl, pd.Series)
+    assert len(pnl) == 2
+
+
+def test_optimize_position_sizing_sharpe():
+    actual = pd.Series([0.01, 0.02, -0.01, 0.02])
+    preds = actual.shift(1).fillna(0)
+    results = optimize_position_sizing(actual, preds)
+    assert "constant_sharpe" in results
+    assert isinstance(results["constant_sharpe"], float)
+
+
+def test_risk_free_rate_effect():
+    actual = pd.Series([0.01, 0.02, -0.01, 0.03])
+    preds = actual.shift(1).fillna(0)
+    res_zero = optimize_position_sizing(actual, preds, risk_free_rate=0.0)
+    res_high = optimize_position_sizing(actual, preds, risk_free_rate=0.1)
+    assert res_high["constant_sharpe"] != res_zero["constant_sharpe"]


### PR DESCRIPTION
## Summary
- use actual historical prices in demo data generation
- support date range, EMA predictions, and interactive chart display
- print total PnL and Sharpe ratio for each parameter combo
- return DataFrame from demo and test new behaviour

## Testing
- `pytest -q tests/test_position_sizing_optimizer.py tests/test_position_sizing_demo.py`

------
https://chatgpt.com/codex/tasks/task_e_68761439a76083338fe40d8f22d38dca