### PR TITLE
Add rlsys reinforcement learning system with tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "torch-optimizer>=0.3",
     "pytorch-optimizer>=2.11",
     "dill==0.3.8",
+    "gymnasium>=0.29",
     "aioboto3==12.4.0",
     "boto3==1.34.69",
     "python-binance>=1.0.21",

--- a/rlsys/__init__.py
+++ b/rlsys/__init__.py
@@ -1,0 +1,27 @@
+"""Unified reinforcement learning system for market simulation and trading."""
+
+from .config import (
+    DataConfig,
+    MarketConfig,
+    PolicyConfig,
+    TrainingConfig,
+    LLMConfig,
+    SystemConfig,
+)
+from .market_environment import MarketEnvironment
+from .policy import ActorCriticPolicy
+from .training import PPOTrainer
+from .llm_guidance import StrategyLLMGuidance
+
+__all__ = [
+    "DataConfig",
+    "MarketConfig",
+    "PolicyConfig",
+    "TrainingConfig",
+    "LLMConfig",
+    "SystemConfig",
+    "MarketEnvironment",
+    "ActorCriticPolicy",
+    "PPOTrainer",
+    "StrategyLLMGuidance",
+]

--- a/rlsys/buffers.py
+++ b/rlsys/buffers.py
@@ -1,0 +1,84 @@
+"""Buffers for storing on-policy rollouts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+import torch
+
+
+@dataclass(slots=True)
+class RolloutBatch:
+    observations: torch.Tensor
+    actions: torch.Tensor
+    log_probs: torch.Tensor
+    advantages: torch.Tensor
+    returns: torch.Tensor
+    values: torch.Tensor
+
+
+class RolloutBuffer:
+    def __init__(self, size: int, observation_dim: int, device: torch.device) -> None:
+        self.capacity = size
+        self.observation_dim = observation_dim
+        self.device = device
+        self.reset()
+
+    def reset(self) -> None:
+        self.observations = torch.zeros((self.capacity, self.observation_dim), device=self.device)
+        self.actions = torch.zeros((self.capacity, 1), device=self.device)
+        self.log_probs = torch.zeros(self.capacity, device=self.device)
+        self.rewards = torch.zeros(self.capacity, device=self.device)
+        self.dones = torch.zeros(self.capacity, device=self.device)
+        self.values = torch.zeros(self.capacity, device=self.device)
+        self.advantages = torch.zeros(self.capacity, device=self.device)
+        self.returns = torch.zeros(self.capacity, device=self.device)
+        self.ptr = 0
+
+    def add(
+        self,
+        observation: torch.Tensor,
+        action: torch.Tensor,
+        log_prob: torch.Tensor,
+        reward: torch.Tensor,
+        done: torch.Tensor,
+        value: torch.Tensor,
+    ) -> None:
+        if self.ptr >= self.capacity:
+            raise RuntimeError("Rollout buffer overflow")
+        self.observations[self.ptr].copy_(observation)
+        self.actions[self.ptr].copy_(action)
+        self.log_probs[self.ptr] = log_prob
+        self.rewards[self.ptr] = reward
+        self.dones[self.ptr] = done
+        self.values[self.ptr] = value
+        self.ptr += 1
+
+    def compute_returns_and_advantages(self, last_value: torch.Tensor, gamma: float, gae_lambda: float) -> None:
+        last_value = last_value.squeeze(-1)
+        last_gae = torch.zeros(1, device=self.device)
+        for step in reversed(range(self.ptr)):
+            mask = 1.0 - self.dones[step]
+            next_value = last_value if step == self.ptr - 1 else self.values[step + 1]
+            delta = self.rewards[step] + gamma * next_value * mask - self.values[step]
+            last_gae = delta + gamma * gae_lambda * mask * last_gae
+            self.advantages[step] = last_gae
+        self.returns = self.advantages + self.values
+        self.advantages = (self.advantages - self.advantages.mean()) / (self.advantages.std(unbiased=False) + 1e-8)
+
+    def get(self, batch_size: int) -> Dict[str, torch.Tensor]:
+        if self.ptr == 0:
+            raise RuntimeError("Rollout buffer is empty")
+        indices = torch.randperm(self.ptr, device=self.device)
+        for start in range(0, self.ptr, batch_size):
+            end = start + batch_size
+            batch_idx = indices[start:end]
+            yield {
+                "observations": self.observations[batch_idx],
+                "actions": self.actions[batch_idx],
+                "log_probs": self.log_probs[batch_idx],
+                "advantages": self.advantages[batch_idx],
+                "returns": self.returns[batch_idx],
+                "values": self.values[batch_idx],
+            }

--- a/rlsys/config.py
+++ b/rlsys/config.py
@@ -1,0 +1,133 @@
+"""Configuration dataclasses for the RL trading system."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional, Sequence, Tuple
+
+
+@dataclass(slots=True)
+class DataConfig:
+    """Configuration describing how price data should be prepared."""
+
+    window_size: int = 64
+    feature_columns: Sequence[str] = field(
+        default_factory=lambda: ("open", "high", "low", "close", "volume")
+    )
+    target_column: str = "close"
+    normalize_returns: bool = True
+    include_technical_indicators: bool = True
+    ema_periods: Tuple[int, int] = (12, 26)
+
+
+@dataclass(slots=True)
+class MarketConfig:
+    """Hyper-parameters for the market execution simulator."""
+
+    initial_capital: float = 1_000_000.0
+    max_leverage: float = 5.0
+    transaction_cost: float = 0.0005
+    slippage: float = 0.0002
+    market_impact: float = 0.0001
+    risk_aversion: float = 0.01
+    min_cash: float = 100.0
+    max_position_change: float = 1.0
+    max_drawdown_threshold: Optional[float] = None
+
+    def clamp_action(self, action: float) -> float:
+        return max(min(action, self.max_leverage), -self.max_leverage)
+
+    def __post_init__(self) -> None:
+        if self.max_drawdown_threshold is not None and self.max_drawdown_threshold <= 0:
+            raise ValueError("max_drawdown_threshold must be positive if provided")
+
+
+@dataclass(slots=True)
+class PolicyConfig:
+    """Model architecture parameters for the actor-critic policy."""
+
+    hidden_sizes: Tuple[int, ...] = (256, 256)
+    activation: str = "silu"
+    dropout: float = 0.05
+    shared_backbone: bool = True
+    value_head_layers: int = 1
+    policy_head_layers: int = 1
+    log_std_bounds: Tuple[float, float] = (-20.0, 2.0)
+
+
+@dataclass(slots=True)
+class TrainingConfig:
+    """Trainer hyper-parameters."""
+
+    total_timesteps: int = 200_000
+    rollout_steps: int = 1_024
+    num_epochs: int = 10
+    minibatch_size: int = 256
+    gamma: float = 0.99
+    gae_lambda: float = 0.95
+    clip_range: float = 0.2
+    clip_range_value: float = 0.2
+    ent_coef: float = 0.01
+    vf_coef: float = 0.5
+    max_grad_norm: float = 1.0
+    learning_rate: float = 3e-4
+    weight_decay: float = 1e-4
+    use_amp: bool = True
+    target_kl: Optional[float] = 0.015
+    device: str | None = None
+    seed: Optional[int] = 42
+    lr_schedule: str = "none"
+    normalize_observations: bool = True
+
+    def __post_init__(self) -> None:
+        if self.minibatch_size > self.rollout_steps:
+            raise ValueError("minibatch_size cannot exceed rollout_steps")
+        if self.rollout_steps % self.minibatch_size != 0:
+            raise ValueError("rollout_steps must be divisible by minibatch_size")
+        if self.total_timesteps < self.rollout_steps:
+            raise ValueError("total_timesteps must be >= rollout_steps")
+        if self.lr_schedule not in {"none", "linear", "cosine"}:
+            raise ValueError("lr_schedule must be 'none', 'linear', or 'cosine'")
+
+
+@dataclass(slots=True)
+class LLMConfig:
+    """Configuration for the LLM-based policy guidance module."""
+
+    enabled: bool = False
+    model_name: str = "meta-llama/Llama-3.2-1B-Instruct"
+    max_new_tokens: int = 128
+    temperature: float = 0.1
+    top_p: float = 0.9
+    strategy_summary_template: str = (
+        "You are an expert quantitative researcher. Summarize risks and "
+        "opportunities for the next training epoch based on the following metrics:\n{metrics}"
+    )
+
+
+@dataclass(slots=True)
+class SystemConfig:
+    """Top-level configuration bundling all subsystems together."""
+
+    data: DataConfig = field(default_factory=DataConfig)
+    market: MarketConfig = field(default_factory=MarketConfig)
+    policy: PolicyConfig = field(default_factory=PolicyConfig)
+    training: TrainingConfig = field(default_factory=TrainingConfig)
+    llm: LLMConfig = field(default_factory=LLMConfig)
+
+    def copy_with(
+        self,
+        *,
+        data: Optional[DataConfig] = None,
+        market: Optional[MarketConfig] = None,
+        policy: Optional[PolicyConfig] = None,
+        training: Optional[TrainingConfig] = None,
+        llm: Optional[LLMConfig] = None,
+    ) -> "SystemConfig":
+        return SystemConfig(
+            data=data or self.data,
+            market=market or self.market,
+            policy=policy or self.policy,
+            training=training or self.training,
+            llm=llm or self.llm,
+        )

--- a/rlsys/data.py
+++ b/rlsys/data.py
@@ -1,0 +1,73 @@
+"""Data loading and feature engineering utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Iterable, Tuple
+
+import numpy as np
+import pandas as pd
+import torch
+
+from .config import DataConfig
+
+
+@dataclass(slots=True)
+class PreparedData:
+    features: torch.Tensor
+    targets: torch.Tensor
+    index: pd.Index
+
+
+def _compute_log_returns(prices: pd.Series) -> pd.Series:
+    return np.log(prices).diff().fillna(0.0)
+
+
+def _ema(series: pd.Series, span: int) -> pd.Series:
+    return series.ewm(span=span, adjust=False).mean()
+
+
+def prepare_features(df: pd.DataFrame, config: DataConfig) -> PreparedData:
+    missing = [col for col in config.feature_columns if col not in df.columns]
+    if missing:
+        raise ValueError(f"Missing required feature columns: {missing}")
+
+    features = df.loc[:, config.feature_columns].astype(float).copy()
+    target = df[config.target_column].astype(float).copy()
+
+    if config.normalize_returns:
+        returns = _compute_log_returns(target)
+        features["return"] = returns
+    else:
+        returns = pd.Series(np.zeros(len(df)), index=df.index)
+        features["return"] = returns
+
+    if config.include_technical_indicators:
+        fast, slow = config.ema_periods
+        features["ema_fast"] = _ema(target, fast)
+        features["ema_slow"] = _ema(target, slow)
+        features["ema_ratio"] = features["ema_fast"] / (features["ema_slow"] + 1e-12)
+        features["volatility"] = returns.rolling(window=config.window_size).std().fillna(0.0)
+
+    features = features.fillna(method="ffill").fillna(method="bfill")
+    tensor_features = torch.tensor(features.values, dtype=torch.float32)
+    tensor_targets = torch.tensor(target.values, dtype=torch.float32)
+    return PreparedData(features=tensor_features, targets=tensor_targets, index=df.index)
+
+
+@lru_cache(maxsize=8)
+def sliding_windows(length: int, window_size: int) -> Tuple[slice, ...]:
+    if window_size <= 0:
+        raise ValueError("window_size must be positive")
+    if window_size > length:
+        raise ValueError("window_size cannot exceed sequence length")
+    return tuple(slice(start, start + window_size) for start in range(length - window_size))
+
+
+def make_training_batches(data: PreparedData, window_size: int) -> Iterable[Tuple[torch.Tensor, torch.Tensor]]:
+    windows = sliding_windows(len(data.features), window_size + 1)
+    for window in windows:
+        obs = data.features[window.start : window.stop - 1]
+        target = data.targets[window.stop - 1]
+        yield obs, target

--- a/rlsys/llm_guidance.py
+++ b/rlsys/llm_guidance.py
@@ -1,0 +1,67 @@
+"""LLM-powered strategic guidance for RL training."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional
+
+from .config import LLMConfig
+
+try:  # pragma: no cover - optional dependency guard
+    from transformers import pipeline
+except Exception:  # pragma: no cover - gracefully degrade
+    pipeline = None
+
+
+@dataclass(slots=True)
+class GuidanceResult:
+    prompt: str
+    response: str
+
+
+class StrategyLLMGuidance:
+    """Generates textual insights from LLMs to steer exploration."""
+
+    def __init__(
+        self,
+        config: LLMConfig,
+        generator: Optional[Callable[[str], str]] = None,
+    ) -> None:
+        self.config = config
+        self._generator = generator
+        self._pipeline: Optional[Any] = None
+
+    def _ensure_pipeline(self):
+        if self._generator is not None or not self.config.enabled:
+            return
+        if self._pipeline is None:
+            if pipeline is None:
+                raise RuntimeError(
+                    "transformers is required for LLM guidance but is not installed"
+                )
+            self._pipeline = pipeline(
+                "text-generation",
+                model=self.config.model_name,
+                torch_dtype="auto",
+            )
+
+    def summarize(self, metrics: Dict[str, float]) -> GuidanceResult:
+        prompt = self.config.strategy_summary_template.format(
+            metrics="\n".join(f"{k}: {v:.6f}" for k, v in sorted(metrics.items()))
+        )
+        if not self.config.enabled:
+            return GuidanceResult(prompt=prompt, response="LLM guidance disabled.")
+        if self._generator is not None:
+            response = self._generator(prompt)
+            return GuidanceResult(prompt=prompt, response=response)
+        self._ensure_pipeline()
+        assert self._pipeline is not None  # for type checkers
+        outputs = self._pipeline(
+            prompt,
+            max_new_tokens=self.config.max_new_tokens,
+            temperature=self.config.temperature,
+            top_p=self.config.top_p,
+            do_sample=True,
+        )
+        text = outputs[0]["generated_text"] if outputs else ""
+        return GuidanceResult(prompt=prompt, response=text)

--- a/rlsys/market_environment.py
+++ b/rlsys/market_environment.py
@@ -1,0 +1,213 @@
+"""Gymnasium environment for realistic market simulation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import gymnasium as gym
+import numpy as np
+
+from .config import MarketConfig
+from .utils import (
+    EpisodeMetrics,
+    compute_max_drawdown,
+    compute_sharpe_ratio,
+    compute_sortino_ratio,
+)
+
+
+@dataclass(slots=True)
+class MarketState:
+    index: int
+    cash: float
+    position: float
+    portfolio_value: float
+    turnover: float
+
+
+class MarketEnvironment(gym.Env):
+    """Event-driven market simulator."""
+
+    metadata = {"render_modes": ["human"]}
+
+    def __init__(
+        self,
+        prices: np.ndarray,
+        features: np.ndarray,
+        config: Optional[MarketConfig] = None,
+        dtype: np.dtype = np.float32,
+    ) -> None:
+        if prices.ndim != 1:
+            raise ValueError("prices must be a 1D array")
+        if len(prices) != len(features):
+            raise ValueError("prices and features must have matching lengths")
+        if len(prices) < 2:
+            raise ValueError("At least two price points are required")
+
+        self.config = config or MarketConfig()
+        self.prices = prices.astype(np.float64)
+        self.features = features.astype(dtype)
+        self.dtype = dtype
+
+        feature_dim = self.features.shape[1]
+        self.observation_space = gym.spaces.Box(
+            low=-np.inf,
+            high=np.inf,
+            shape=(feature_dim + 3,),
+            dtype=np.float32,
+        )
+        self.action_space = gym.spaces.Box(
+            low=-self.config.max_leverage,
+            high=self.config.max_leverage,
+            shape=(1,),
+            dtype=np.float32,
+        )
+
+        self._state: Optional[MarketState] = None
+        self._returns: list[float] = []
+        self._equity_curve: list[float] = []
+        self._last_action: float = 0.0
+        self._peak_value = self.config.initial_capital
+
+    def reset(self, *, seed: Optional[int] = None, options: Optional[Dict] = None):
+        super().reset(seed=seed)
+        del options
+        initial_value = self.config.initial_capital
+        self._state = MarketState(
+            index=0,
+            cash=initial_value,
+            position=0.0,
+            portfolio_value=initial_value,
+            turnover=0.0,
+        )
+        self._returns = []
+        self._equity_curve = [initial_value]
+        self._last_action = 0.0
+        self._peak_value = initial_value
+        return self._get_observation(), {}
+
+    def step(self, action: np.ndarray):
+        if self._state is None:
+            raise RuntimeError("Environment must be reset before stepping")
+        action_value = float(np.clip(action[0], -self.config.max_leverage, self.config.max_leverage))
+        state = self._state
+
+        current_price = self.prices[state.index]
+        next_index = state.index + 1
+        next_price = self.prices[next_index]
+
+        prev_value = state.portfolio_value
+        prev_position = state.position
+        target_position = action_value
+        delta = float(
+            np.clip(
+                target_position - prev_position,
+                -self.config.max_position_change,
+                self.config.max_position_change,
+            )
+        )
+        target_position = prev_position + delta
+
+        price_return = (next_price - current_price) / current_price
+        trade_penalty = abs(delta) * (
+            self.config.transaction_cost
+            + self.config.slippage
+            + self.config.market_impact * abs(delta)
+        )
+        reward = target_position * price_return - trade_penalty
+        reward -= self.config.risk_aversion * (target_position**2)
+
+        new_portfolio_value = prev_value * (1.0 + reward)
+        if not np.isfinite(new_portfolio_value):
+            new_portfolio_value = self.config.min_cash
+        new_portfolio_value = max(new_portfolio_value, 0.0)
+        new_cash = new_portfolio_value * max(0.0, 1.0 - abs(target_position))
+        new_turnover = state.turnover + abs(delta)
+
+        state = MarketState(
+            index=next_index,
+            cash=new_cash,
+            position=target_position,
+            portfolio_value=new_portfolio_value,
+            turnover=new_turnover,
+        )
+        self._state = state
+
+        done = (
+            next_index >= len(self.prices) - 1
+            or new_cash < self.config.min_cash
+            or new_portfolio_value < self.config.min_cash
+        )
+        truncated = False
+
+        self._returns.append(reward)
+        self._equity_curve.append(new_portfolio_value)
+        self._peak_value = max(self._peak_value, new_portfolio_value)
+        drawdown = 0.0
+        if self._peak_value > 0:
+            drawdown = (new_portfolio_value - self._peak_value) / self._peak_value
+        drawdown_triggered = (
+            self.config.max_drawdown_threshold is not None
+            and drawdown <= -self.config.max_drawdown_threshold
+        )
+        self._last_action = action_value
+
+        obs = self._get_observation()
+        info = {
+            "portfolio_value": new_portfolio_value,
+            "position": state.position,
+            "turnover": new_turnover,
+            "drawdown": float(drawdown),
+            "drawdown_triggered": drawdown_triggered,
+        }
+        if drawdown_triggered:
+            done = True
+        if done:
+            metrics = self._finalize_metrics()
+            info.update(metrics.as_dict())
+        return obs, reward, done, truncated, info
+
+    def render(self):
+        if self._state is None:
+            return {}
+        return {
+            "index": self._state.index,
+            "portfolio_value": self._state.portfolio_value,
+            "position": self._state.position,
+            "cash": self._state.cash,
+            "last_action": self._last_action,
+        }
+
+    def _get_observation(self) -> np.ndarray:
+        if self._state is None:
+            raise RuntimeError("Environment not initialized")
+        idx = self._state.index
+        obs_features = self.features[idx]
+        augmented = np.concatenate(
+            [
+                obs_features,
+                np.asarray(
+                    [
+                        self._state.position,
+                        self._state.cash / self.config.initial_capital,
+                        self._state.portfolio_value / self.config.initial_capital,
+                    ],
+                    dtype=self.dtype,
+                ),
+            ]
+        )
+        return augmented.astype(self.dtype, copy=False)
+
+    def _finalize_metrics(self) -> EpisodeMetrics:
+        sharpe = compute_sharpe_ratio(self._returns)
+        max_dd = compute_max_drawdown(self._equity_curve)
+        sortino = compute_sortino_ratio(self._returns)
+        return EpisodeMetrics(
+            reward=float(sum(self._returns)),
+            length=len(self._returns),
+            max_drawdown=float(max_dd),
+            sharpe_ratio=float(sharpe),
+            turnover=float(self._state.turnover if self._state else 0.0),
+            sortino_ratio=float(sortino),
+        )

--- a/rlsys/policy.py
+++ b/rlsys/policy.py
@@ -1,0 +1,132 @@
+"""Actor-critic policy network with modern PyTorch best practices."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Tuple
+
+import torch
+from torch import nn
+from torch.distributions import Normal
+
+from .config import PolicyConfig
+
+_ACTIVATIONS: Dict[str, Callable[[], nn.Module]] = {
+    "relu": nn.ReLU,
+    "gelu": nn.GELU,
+    "silu": nn.SiLU,
+    "elu": nn.ELU,
+}
+
+
+def _make_activation(name: str) -> nn.Module:
+    try:
+        return _ACTIVATIONS[name.lower()]()
+    except KeyError as exc:  # pragma: no cover - defensive
+        raise ValueError(f"Unsupported activation: {name}") from exc
+
+
+class _MLP(nn.Module):
+    def __init__(self, input_dim: int, hidden_sizes: Tuple[int, ...], activation: nn.Module, dropout: float) -> None:
+        super().__init__()
+        layers = []
+        last_dim = input_dim
+        for hidden in hidden_sizes:
+            layers.append(nn.Linear(last_dim, hidden))
+            layers.append(nn.LayerNorm(hidden))
+            layers.append(activation.__class__())
+            if dropout > 0:
+                layers.append(nn.Dropout(dropout))
+            last_dim = hidden
+        self.net = nn.Sequential(*layers)
+        self.output_dim = last_dim
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # pragma: no cover - thin wrapper
+        return self.net(x)
+
+
+class ActorCriticPolicy(nn.Module):
+    """Gaussian actor-critic policy."""
+
+    def __init__(self, observation_dim: int, config: PolicyConfig) -> None:
+        super().__init__()
+        activation = _make_activation(config.activation)
+        hidden_sizes = tuple(config.hidden_sizes)
+        if not hidden_sizes:
+            raise ValueError("At least one hidden layer is required")
+
+        if config.shared_backbone:
+            self.backbone = _MLP(observation_dim, hidden_sizes, activation, config.dropout)
+            actor_input_dim = self.backbone.output_dim
+            critic_input_dim = self.backbone.output_dim
+        else:
+            self.backbone = None
+            self.actor_body = _MLP(observation_dim, hidden_sizes, activation, config.dropout)
+            self.critic_body = _MLP(observation_dim, hidden_sizes, activation, config.dropout)
+            actor_input_dim = self.actor_body.output_dim
+            critic_input_dim = self.critic_body.output_dim
+
+        policy_layers = []
+        last_dim = actor_input_dim
+        for _ in range(config.policy_head_layers - 1):
+            policy_layers.extend(
+                [
+                    nn.Linear(last_dim, last_dim),
+                    nn.LayerNorm(last_dim),
+                    activation.__class__(),
+                ]
+            )
+        self.policy_head = nn.Sequential(*policy_layers, nn.Linear(last_dim, 1))
+
+        value_layers = []
+        last_dim_v = critic_input_dim
+        for _ in range(config.value_head_layers - 1):
+            value_layers.extend(
+                [
+                    nn.Linear(last_dim_v, last_dim_v),
+                    nn.LayerNorm(last_dim_v),
+                    activation.__class__(),
+                ]
+            )
+        self.value_head = nn.Sequential(*value_layers, nn.Linear(last_dim_v, 1))
+
+        self.log_std = nn.Parameter(torch.zeros(1))
+        self.log_std_bounds = config.log_std_bounds
+
+        self.apply(self._init_weights)
+
+    @staticmethod
+    def _init_weights(module: nn.Module) -> None:
+        if isinstance(module, nn.Linear):
+            nn.init.kaiming_uniform_(module.weight, nonlinearity="relu")
+            if module.bias is not None:
+                nn.init.zeros_(module.bias)
+
+    def _forward_backbone(self, observation: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        if self.backbone is not None:
+            hidden = self.backbone(observation)
+            return hidden, hidden
+        actor_hidden = self.actor_body(observation)
+        critic_hidden = self.critic_body(observation)
+        return actor_hidden, critic_hidden
+
+    def forward(self, observation: torch.Tensor) -> Tuple[Normal, torch.Tensor]:
+        actor_hidden, critic_hidden = self._forward_backbone(observation)
+        mean = self.policy_head(actor_hidden)
+        value = self.value_head(critic_hidden)
+        log_std = torch.clamp(self.log_std, *self.log_std_bounds)
+        std = torch.exp(log_std)
+        return Normal(mean, std), value
+
+    def act(self, observation: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        distribution, value = self.forward(observation)
+        action = distribution.sample()
+        log_prob = distribution.log_prob(action).sum(-1)
+        return action, log_prob, value
+
+    def evaluate_actions(
+        self, observation: torch.Tensor, actions: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        distribution, value = self.forward(observation)
+        log_probs = distribution.log_prob(actions).sum(-1)
+        entropy = distribution.entropy().sum(-1)
+        return log_probs, entropy, value

--- a/rlsys/training.py
+++ b/rlsys/training.py
@@ -1,0 +1,280 @@
+"""PPO trainer optimized for trading environments."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Dict, Iterable, Optional
+
+import numpy as np
+import torch
+from torch.cuda.amp import GradScaler, autocast
+
+from .buffers import RolloutBuffer
+from .config import MarketConfig, TrainingConfig
+from .llm_guidance import StrategyLLMGuidance
+from .market_environment import MarketEnvironment
+from .policy import ActorCriticPolicy
+from .utils import ObservationNormalizer, EpisodeMetrics, get_device, seed_everything, update_dict
+
+
+@dataclass(slots=True)
+class TrainingState:
+    global_step: int = 0
+    episode: int = 0
+
+
+class PPOTrainer:
+    def __init__(
+        self,
+        env: MarketEnvironment,
+        policy: ActorCriticPolicy,
+        training_config: TrainingConfig,
+        market_config: Optional[MarketConfig] = None,
+        guidance: Optional[StrategyLLMGuidance] = None,
+    ) -> None:
+        self.env = env
+        self.policy = policy
+        self.config = training_config
+        self.market_config = market_config or MarketConfig()
+        self.guidance = guidance
+
+        seed_everything(self.config.seed)
+        self.device = get_device(self.config.device)
+        self.policy.to(self.device)
+
+        observation_dim = env.observation_space.shape[0]
+        self.buffer = RolloutBuffer(self.config.rollout_steps, observation_dim, self.device)
+
+        adamw_kwargs = {
+            "lr": self.config.learning_rate,
+            "weight_decay": self.config.weight_decay,
+        }
+        if torch.cuda.is_available():
+            adamw_kwargs["fused"] = True
+        self.optimizer = torch.optim.AdamW(self.policy.parameters(), **adamw_kwargs)
+        self.scaler = GradScaler(enabled=self.config.use_amp and torch.cuda.is_available())
+        self.state = TrainingState()
+        self._last_obs = np.zeros(observation_dim, dtype=np.float32)
+        self._last_done = True
+        self.total_updates = max(1, math.ceil(self.config.total_timesteps / self.config.rollout_steps))
+        self.updates_completed = 0
+        self._normalizer = (
+            ObservationNormalizer(observation_dim, device=self.device)
+            if self.config.normalize_observations
+            else None
+        )
+
+    def collect_rollout(self) -> EpisodeMetrics:
+        self.buffer.reset()
+        obs, _ = self.env.reset()
+        episodes: list[EpisodeMetrics] = []
+        last_done = False
+        for step in range(self.config.rollout_steps):
+            obs_tensor = torch.tensor(obs, dtype=torch.float32, device=self.device)
+            obs_tensor = self._normalize_observation(obs_tensor, update=True)
+            with torch.no_grad():
+                action, log_prob, value = self.policy.act(obs_tensor.unsqueeze(0))
+            action_np = action.squeeze(0).cpu().numpy()
+            next_obs, reward, done, truncated, info = self.env.step(action_np)
+
+            reward_tensor = torch.tensor(reward, dtype=torch.float32, device=self.device)
+            done_tensor = torch.tensor(float(done), dtype=torch.float32, device=self.device)
+            self.buffer.add(
+                observation=obs_tensor,
+                action=action.squeeze(0),
+                log_prob=log_prob.squeeze(0),
+                reward=reward_tensor,
+                done=done_tensor,
+                value=value.squeeze(),
+            )
+
+            self.state.global_step += 1
+            obs = next_obs
+            last_done = bool(done or truncated)
+
+            if done or truncated:
+                episode_metric = EpisodeMetrics(
+                    reward=float(info.get("episode_reward", reward)),
+                    length=int(info.get("episode_length", step + 1)),
+                    max_drawdown=float(info.get("episode_max_drawdown", 0.0)),
+                    sharpe_ratio=float(info.get("episode_sharpe", 0.0)),
+                    turnover=float(info.get("episode_turnover", 0.0)),
+                    sortino_ratio=float(info.get("episode_sortino", 0.0)),
+                )
+                episodes.append(episode_metric)
+                self.state.episode += 1
+                if step < self.config.rollout_steps - 1:
+                    obs, _ = self.env.reset()
+            if self.state.global_step >= self.config.total_timesteps:
+                break
+        if episodes:
+            avg_reward = float(np.mean([e.reward for e in episodes]))
+            avg_length = int(np.mean([e.length for e in episodes]))
+            avg_sharpe = float(np.mean([e.sharpe_ratio for e in episodes]))
+            avg_turnover = float(np.mean([e.turnover for e in episodes]))
+            avg_sortino = float(np.mean([e.sortino_ratio for e in episodes]))
+            worst_drawdown = float(min(e.max_drawdown for e in episodes))
+            episode_metrics = EpisodeMetrics(
+                reward=avg_reward,
+                length=avg_length,
+                max_drawdown=worst_drawdown,
+                sharpe_ratio=avg_sharpe,
+                turnover=avg_turnover,
+                sortino_ratio=avg_sortino,
+            )
+        else:
+            episode_metrics = EpisodeMetrics(
+                reward=0.0,
+                length=0,
+                max_drawdown=0.0,
+                sharpe_ratio=0.0,
+                turnover=0.0,
+                sortino_ratio=0.0,
+            )
+        last_tensor = torch.tensor(obs, dtype=torch.float32, device=self.device)
+        last_tensor = self._normalize_observation(last_tensor, update=False)
+        self._last_obs = last_tensor.detach().cpu().numpy()
+        self._last_done = last_done
+        return episode_metrics
+
+    def _update_policy(self) -> Dict[str, float]:
+        last_obs = torch.tensor(self._last_obs, dtype=torch.float32, device=self.device)
+        if self._last_done:
+            last_value = torch.zeros(1, device=self.device)
+        else:
+            with torch.no_grad():
+                _, _, last_value = self.policy.act(last_obs.unsqueeze(0))
+        self.buffer.compute_returns_and_advantages(last_value, self.config.gamma, self.config.gae_lambda)
+
+        metrics: Dict[str, float] = {}
+        updates = 0
+        for _ in range(self.config.num_epochs):
+            for batch in self.buffer.get(self.config.minibatch_size):
+                loss_dict = self._ppo_loss(batch)
+                for key, value in loss_dict.items():
+                    metrics[key] = metrics.get(key, 0.0) + float(value)
+                updates += 1
+        if updates:
+            metrics = {key: value / updates for key, value in metrics.items()}
+        return metrics
+
+    def _ppo_loss(self, batch: Dict[str, torch.Tensor]) -> Dict[str, float]:
+        observations = batch["observations"]
+        actions = batch["actions"]
+        old_log_probs = batch["log_probs"]
+        advantages = batch["advantages"]
+        returns = batch["returns"]
+        old_values = batch["values"]
+
+        with autocast(enabled=self.scaler.is_enabled()):
+            log_probs, entropy, values = self.policy.evaluate_actions(observations, actions)
+            ratio = torch.exp(log_probs - old_log_probs)
+            clipped_ratio = torch.clamp(ratio, 1.0 - self.config.clip_range, 1.0 + self.config.clip_range)
+            policy_loss = -torch.min(ratio * advantages, clipped_ratio * advantages).mean()
+
+            value_pred_clipped = old_values + torch.clamp(
+                values - old_values, -self.config.clip_range_value, self.config.clip_range_value
+            )
+            value_losses = (values - returns).pow(2)
+            value_losses_clipped = (value_pred_clipped - returns).pow(2)
+            value_loss = 0.5 * torch.max(value_losses, value_losses_clipped).mean()
+
+            entropy_loss = -entropy.mean()
+            loss = policy_loss + self.config.vf_coef * value_loss + self.config.ent_coef * entropy_loss
+
+        self.optimizer.zero_grad(set_to_none=True)
+        if self.scaler.is_enabled():
+            self.scaler.scale(loss).backward()
+            self.scaler.unscale_(self.optimizer)
+            torch.nn.utils.clip_grad_norm_(self.policy.parameters(), self.config.max_grad_norm)
+            self.scaler.step(self.optimizer)
+            self.scaler.update()
+        else:
+            loss.backward()
+            torch.nn.utils.clip_grad_norm_(self.policy.parameters(), self.config.max_grad_norm)
+            self.optimizer.step()
+
+        approx_kl = torch.mean(old_log_probs - log_probs).item()
+        clip_frac = (torch.abs(ratio - 1.0) > self.config.clip_range).float().mean().item()
+        metrics = {
+            "loss_policy": float(policy_loss.detach().cpu()),
+            "loss_value": float(value_loss.detach().cpu()),
+            "loss_entropy": float(entropy_loss.detach().cpu()),
+            "loss_total": float(loss.detach().cpu()),
+            "approx_kl": approx_kl,
+            "clip_fraction": clip_frac,
+        }
+        return metrics
+
+    def train(self) -> Iterable[Dict[str, float]]:
+        while self.state.global_step < self.config.total_timesteps:
+            episode_metrics = self.collect_rollout()
+            metrics = self._update_policy()
+            iteration_logs: Dict[str, float] = {}
+            update_dict(iteration_logs, metrics)
+            update_dict(iteration_logs, episode_metrics.as_dict())
+
+            if self.config.target_kl and metrics.get("approx_kl", 0.0) > 1.5 * self.config.target_kl:
+                self.updates_completed += 1
+                current_lr = self._apply_lr_schedule()
+                iteration_logs["learning_rate"] = current_lr
+                yield iteration_logs
+                break
+
+            if self.guidance is not None:
+                guidance_result = self.guidance.summarize(iteration_logs)
+                update_dict(
+                    iteration_logs,
+                    {"guidance_tokens": float(len(guidance_result.response.split()))},
+                )
+            self.updates_completed += 1
+            current_lr = self._apply_lr_schedule()
+            iteration_logs["learning_rate"] = current_lr
+            yield iteration_logs
+
+    def evaluate(self, num_episodes: int = 5) -> Dict[str, float]:
+        returns = []
+        sharpe_ratios = []
+        for _ in range(num_episodes):
+            obs, _ = self.env.reset()
+            done = False
+            total_reward = 0.0
+            while not done:
+                obs_tensor = torch.tensor(obs, dtype=torch.float32, device=self.device)
+                obs_tensor = self._normalize_observation(obs_tensor, update=False)
+                with torch.no_grad():
+                    action, _, _ = self.policy.act(obs_tensor.unsqueeze(0))
+                obs, reward, done, truncated, info = self.env.step(action.squeeze(0).cpu().numpy())
+                total_reward += reward
+                if truncated:
+                    break
+            returns.append(total_reward)
+            sharpe_ratios.append(info.get("episode_sharpe", 0.0))
+        return {
+            "eval_return_mean": float(np.mean(returns)),
+            "eval_return_std": float(np.std(returns)),
+            "eval_sharpe_mean": float(np.mean(sharpe_ratios)),
+        }
+
+    def _apply_lr_schedule(self) -> float:
+        if self.config.lr_schedule == "none":
+            return float(self.optimizer.param_groups[0]["lr"])
+        progress_remaining = max(0.0, 1.0 - self.updates_completed / self.total_updates)
+        if self.config.lr_schedule == "linear":
+            lr = self.config.learning_rate * progress_remaining
+        else:
+            lr = self.config.learning_rate * 0.5 * (
+                1.0 + math.cos(math.pi * (1.0 - progress_remaining))
+            )
+        lr = float(max(lr, 1e-8))
+        for group in self.optimizer.param_groups:
+            group["lr"] = lr
+        return lr
+
+    def _normalize_observation(self, observation: torch.Tensor, update: bool) -> torch.Tensor:
+        if self._normalizer is None:
+            return observation
+        if update:
+            self._normalizer.update(observation)
+        return self._normalizer.normalize(observation)

--- a/rlsys/utils.py
+++ b/rlsys/utils.py
@@ -1,0 +1,126 @@
+"""Utility helpers for the RL system."""
+
+from __future__ import annotations
+
+import math
+import random
+from dataclasses import dataclass
+from typing import Dict, Iterable, Mapping, MutableMapping, Optional
+
+import numpy as np
+import torch
+
+
+@dataclass(slots=True)
+class EpisodeMetrics:
+    """Container for aggregated episode statistics."""
+
+    reward: float
+    length: int
+    max_drawdown: float
+    sharpe_ratio: float
+    turnover: float
+    sortino_ratio: float
+
+    def as_dict(self) -> Dict[str, float]:
+        return {
+            "episode_reward": self.reward,
+            "episode_length": float(self.length),
+            "episode_max_drawdown": self.max_drawdown,
+            "episode_sharpe": self.sharpe_ratio,
+            "episode_turnover": self.turnover,
+            "episode_sortino": self.sortino_ratio,
+        }
+
+
+def compute_sharpe_ratio(returns: Iterable[float], eps: float = 1e-8) -> float:
+    arr = np.asarray(tuple(returns), dtype=np.float64)
+    if arr.size < 2:
+        return 0.0
+    mean = float(arr.mean())
+    std = float(arr.std(ddof=1))
+    if std < eps:
+        return 0.0
+    return math.sqrt(252.0) * mean / (std + eps)
+
+
+def compute_sortino_ratio(returns: Iterable[float], eps: float = 1e-8, target: float = 0.0) -> float:
+    arr = np.asarray(tuple(returns), dtype=np.float64)
+    if arr.size == 0:
+        return 0.0
+    downside = np.clip(target - arr, a_min=0.0, a_max=None)
+    downside_std = float(np.sqrt(np.mean(np.square(downside))))
+    if downside_std < eps:
+        return 0.0
+    mean_excess = float(arr.mean() - target)
+    return math.sqrt(252.0) * mean_excess / (downside_std + eps)
+
+
+def compute_max_drawdown(equity_curve: Iterable[float]) -> float:
+    arr = np.asarray(tuple(equity_curve), dtype=np.float64)
+    if arr.size == 0:
+        return 0.0
+    peaks = np.maximum.accumulate(arr)
+    drawdowns = (arr - peaks) / peaks
+    return float(drawdowns.min(initial=0.0))
+
+
+def seed_everything(seed: Optional[int]) -> None:
+    if seed is None:
+        return
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def get_device(preferred: Optional[str] = None) -> torch.device:
+    if preferred:
+        return torch.device(preferred)
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    if torch.backends.mps.is_available():  # type: ignore[attr-defined]
+        return torch.device("mps")
+    return torch.device("cpu")
+
+
+def update_dict(target: MutableMapping[str, float], updates: Mapping[str, float]) -> None:
+    for key, value in updates.items():
+        target[key] = float(value)
+
+
+def discounted_returns(rewards: Iterable[float], gamma: float) -> np.ndarray:
+    returns = []
+    running = 0.0
+    for reward in reversed(tuple(rewards)):
+        running = reward + gamma * running
+        returns.append(running)
+    return np.asarray(list(reversed(returns)), dtype=np.float64)
+
+
+class ObservationNormalizer:
+    """Tracks running statistics to normalize observations online."""
+
+    def __init__(self, size: int, device: Optional[torch.device] = None, eps: float = 1e-6) -> None:
+        self.mean = torch.zeros(size, device=device)
+        self.m2 = torch.zeros(size, device=device)
+        self.count = 0
+        self.eps = eps
+
+    def update(self, value: torch.Tensor) -> None:
+        tensor = value.detach()
+        if tensor.dim() != 1 or tensor.shape != self.mean.shape:
+            raise ValueError("ObservationNormalizer expects 1D tensors matching initialized shape")
+        self.count += 1
+        delta = tensor - self.mean
+        self.mean += delta / self.count
+        delta2 = tensor - self.mean
+        self.m2 += delta * delta2
+
+    def normalize(self, value: torch.Tensor) -> torch.Tensor:
+        if self.count < 2:
+            return value
+        variance = self.m2 / (self.count - 1)
+        std = torch.sqrt(variance + self.eps)
+        return (value - self.mean) / std

--- a/tests/rlsys/test_llm_guidance.py
+++ b/tests/rlsys/test_llm_guidance.py
@@ -1,0 +1,24 @@
+from rlsys.config import LLMConfig
+from rlsys.llm_guidance import StrategyLLMGuidance
+
+
+def test_guidance_disabled_returns_placeholder():
+    config = LLMConfig(enabled=False)
+    guidance = StrategyLLMGuidance(config)
+    result = guidance.summarize({"reward": 1.0, "drawdown": -0.1})
+    assert "disabled" in result.response.lower()
+    assert "reward" in result.prompt
+
+
+def test_guidance_uses_custom_generator():
+    messages = []
+
+    def generator(prompt: str) -> str:
+        messages.append(prompt)
+        return "Consider reducing leverage."
+
+    config = LLMConfig(enabled=True)
+    guidance = StrategyLLMGuidance(config, generator=generator)
+    result = guidance.summarize({"reward": 0.5, "sharpe": 1.2})
+    assert messages and messages[0] == result.prompt
+    assert "reducing" in result.response.lower()

--- a/tests/rlsys/test_market_environment.py
+++ b/tests/rlsys/test_market_environment.py
@@ -1,0 +1,71 @@
+import numpy as np
+
+from rlsys.config import MarketConfig
+from rlsys.market_environment import MarketEnvironment
+
+
+def test_market_environment_step_and_metrics():
+    prices = np.linspace(100.0, 110.0, num=120, dtype=np.float64)
+    feature_dim = 5
+    features = np.stack(
+        [
+            np.linspace(0.1, 1.0, num=120, dtype=np.float32) + i
+            for i in range(feature_dim)
+        ],
+        axis=1,
+    )
+    config = MarketConfig(
+        initial_capital=100_000.0,
+        max_leverage=2.0,
+        transaction_cost=0.0001,
+        slippage=0.0001,
+        market_impact=0.0,
+        risk_aversion=0.0,
+        max_position_change=0.5,
+    )
+    env = MarketEnvironment(prices=prices, features=features, config=config)
+
+    observation, info = env.reset()
+    assert observation.shape[0] == feature_dim + 3
+    assert info == {}
+
+    total_reward = 0.0
+    for _ in range(50):
+        action = np.array([0.4], dtype=np.float32)
+        observation, reward, done, truncated, info = env.step(action)
+        assert np.isfinite(reward)
+        total_reward += reward
+        render = env.render()
+        assert abs(render["position"]) <= config.max_leverage + 1e-6
+        if done or truncated:
+            assert "episode_reward" in info
+            assert np.isfinite(info["episode_sharpe"])
+            assert "episode_sortino" in info
+            assert np.isfinite(info["episode_sortino"])
+            break
+    assert np.isfinite(total_reward)
+
+
+def test_market_environment_drawdown_threshold_triggers_done():
+    prices = np.array([100.0, 99.0, 97.0, 95.0, 93.0], dtype=np.float64)
+    features = np.ones((prices.shape[0], 3), dtype=np.float32)
+    config = MarketConfig(
+        initial_capital=10_000.0,
+        max_leverage=1.0,
+        transaction_cost=0.0,
+        slippage=0.0,
+        risk_aversion=0.0,
+        max_position_change=1.0,
+        min_cash=0.0,
+        max_drawdown_threshold=0.02,
+    )
+    env = MarketEnvironment(prices=prices, features=features, config=config)
+
+    env.reset()
+    done = False
+    while not done:
+        _, _, done, _, info = env.step(np.array([1.0], dtype=np.float32))
+        if done:
+            assert info["drawdown_triggered"]
+            assert info["drawdown"] <= -config.max_drawdown_threshold
+            break

--- a/tests/rlsys/test_training_pipeline.py
+++ b/tests/rlsys/test_training_pipeline.py
@@ -1,0 +1,116 @@
+import math
+
+import numpy as np
+import pandas as pd
+
+from rlsys.config import DataConfig, MarketConfig, PolicyConfig, TrainingConfig
+from rlsys.data import prepare_features
+from rlsys.market_environment import MarketEnvironment
+from rlsys.policy import ActorCriticPolicy
+from rlsys.training import PPOTrainer
+
+
+def _make_dataframe(length: int = 256) -> pd.DataFrame:
+    index = pd.date_range("2024-01-01", periods=length, freq="H")
+    base_price = 100 + np.sin(np.linspace(0, 20, length)) * 2
+    data = {
+        "open": base_price + np.random.normal(0, 0.1, size=length),
+        "high": base_price + 0.5,
+        "low": base_price - 0.5,
+        "close": base_price + np.random.normal(0, 0.1, size=length),
+        "volume": np.random.uniform(1_000, 5_000, size=length),
+    }
+    return pd.DataFrame(data, index=index)
+
+
+def test_trainer_produces_finite_metrics():
+    df = _make_dataframe(160)
+    data_config = DataConfig(window_size=16)
+    prepared = prepare_features(df, data_config)
+    prices = prepared.targets.numpy()
+    features = prepared.features.numpy()
+
+    market_config = MarketConfig(initial_capital=50_000.0, max_leverage=1.5, risk_aversion=0.01)
+    env = MarketEnvironment(prices=prices, features=features, config=market_config)
+
+    policy_config = PolicyConfig(hidden_sizes=(64, 64), dropout=0.0)
+    policy = ActorCriticPolicy(observation_dim=env.observation_space.shape[0], config=policy_config)
+
+    training_config = TrainingConfig(
+        total_timesteps=64,
+        rollout_steps=32,
+        num_epochs=2,
+        minibatch_size=8,
+        gamma=0.98,
+        gae_lambda=0.9,
+        use_amp=False,
+        seed=7,
+    )
+
+    trainer = PPOTrainer(env, policy, training_config)
+    logs = next(trainer.train())
+
+    assert all(math.isfinite(value) for value in logs.values()), logs
+    assert "loss_policy" in logs
+    assert "episode_reward" in logs
+    assert "episode_sortino" in logs
+
+    eval_metrics = trainer.evaluate(num_episodes=2)
+    assert set(eval_metrics.keys()) == {"eval_return_mean", "eval_return_std", "eval_sharpe_mean"}
+    assert all(math.isfinite(value) for value in eval_metrics.values())
+
+
+def test_linear_lr_schedule_updates_learning_rate():
+    df = _make_dataframe(120)
+    data_config = DataConfig(window_size=16)
+    prepared = prepare_features(df, data_config)
+    prices = prepared.targets.numpy()
+    features = prepared.features.numpy()
+
+    market_config = MarketConfig(initial_capital=25_000.0, max_leverage=1.0, risk_aversion=0.0)
+    env = MarketEnvironment(prices=prices, features=features, config=market_config)
+
+    policy_config = PolicyConfig(hidden_sizes=(32, 32), dropout=0.0)
+    policy = ActorCriticPolicy(observation_dim=env.observation_space.shape[0], config=policy_config)
+
+    training_config = TrainingConfig(
+        total_timesteps=64,
+        rollout_steps=32,
+        num_epochs=1,
+        minibatch_size=8,
+        use_amp=False,
+        seed=3,
+        lr_schedule="linear",
+    )
+
+    trainer = PPOTrainer(env, policy, training_config)
+    initial_lr = trainer.optimizer.param_groups[0]["lr"]
+    logs = next(trainer.train())
+    assert logs["learning_rate"] < initial_lr
+
+
+def test_trainer_can_disable_observation_normalization():
+    df = _make_dataframe(80)
+    prepared = prepare_features(df, DataConfig(window_size=8))
+    prices = prepared.targets.numpy()
+    features = prepared.features.numpy()
+
+    env = MarketEnvironment(
+        prices=prices,
+        features=features,
+        config=MarketConfig(initial_capital=10_000.0, max_leverage=1.0, risk_aversion=0.0),
+    )
+    policy = ActorCriticPolicy(
+        observation_dim=env.observation_space.shape[0],
+        config=PolicyConfig(hidden_sizes=(16, 16), dropout=0.0),
+    )
+    training_config = TrainingConfig(
+        total_timesteps=32,
+        rollout_steps=16,
+        minibatch_size=8,
+        num_epochs=1,
+        use_amp=False,
+        normalize_observations=False,
+    )
+    trainer = PPOTrainer(env, policy, training_config)
+    assert trainer._normalizer is None

--- a/tests/rlsys/test_utils.py
+++ b/tests/rlsys/test_utils.py
@@ -1,0 +1,11 @@
+import torch
+
+from rlsys.utils import ObservationNormalizer
+
+
+def test_observation_normalizer_centers_data():
+    normalizer = ObservationNormalizer(size=2)
+    normalizer.update(torch.tensor([1.0, 2.0]))
+    normalizer.update(torch.tensor([2.0, 3.0]))
+    normalized = normalizer.normalize(torch.tensor([1.5, 2.5]))
+    assert torch.allclose(normalized, torch.zeros_like(normalized), atol=1e-5)


### PR DESCRIPTION
## Summary
- add a modular rlsys package with configurations, data preparation, market environment, policy, trainer, and LLM guidance utilities
- expose enhanced risk metrics including drawdown threshold handling and Sortino ratio in the new Gymnasium-based market simulator
- provide extensive pytest coverage for environment behavior, training loop, learning-rate scheduling, observation normalization, and LLM guidance helpers

## Testing
- `pytest tests/rlsys -q`


------
https://chatgpt.com/codex/tasks/task_e_690054a8c6d08333b6d68081e446b8dc