### PR TITLE
Enable priority-based MaxDiff watcher overrides

### DIFF
--- a/marketsimulator/process_utils_mock.py
+++ b/marketsimulator/process_utils_mock.py
@@ -58,21 +58,37 @@ def spawn_open_position_at_maxdiff_takeprofit(
     target_qty: float,
     tolerance_pct: float = 0.0066,
     expiry_minutes: int = 60 * 24,
+    poll_seconds: int = 45,
+    *,
+    force_immediate: bool = False,
+    priority_rank: Optional[int] = None,
 ):
     logger.info(
-        "[sim] Maxdiff staged entry for %s side=%s qty=%s limit=%.4f tol=%.4f expiry=%s",
+        "[sim] Maxdiff staged entry for %s side=%s qty=%s limit=%.4f tol=%.4f expiry=%s poll=%s force_immediate=%s priority=%s",
         symbol,
         side,
         target_qty,
         limit_price,
         tolerance_pct,
         expiry_minutes,
+        poll_seconds,
+        force_immediate,
+        priority_rank,
     )
     try:
         state = get_state()
     except RuntimeError:
         return
-    state.register_maxdiff_entry(symbol, side, limit_price, target_qty, tolerance_pct, expiry_minutes)
+    state.register_maxdiff_entry(
+        symbol,
+        side,
+        limit_price,
+        target_qty,
+        tolerance_pct,
+        expiry_minutes,
+        force_immediate=force_immediate,
+        priority_rank=priority_rank,
+    )
 
 
 def spawn_close_position_at_maxdiff_takeprofit(

--- a/tests/prod/utils/test_process_utils.py
+++ b/tests/prod/utils/test_process_utils.py
@@ -44,6 +44,41 @@ def test_spawn_open_replaces_existing_watcher(tmp_watchers_dir, monkeypatch):
     assert metadata["pid"] == dummy_process.pid
     assert metadata["state"] == "launched"
     assert metadata["poll_seconds"] == process_utils.MAXDIFF_ENTRY_DEFAULT_POLL_SECONDS
+    assert metadata["force_immediate"] is False
+    assert "priority_rank" not in metadata
+
+
+def test_spawn_open_force_immediate_sets_metadata(tmp_watchers_dir, monkeypatch):
+    symbol = "MSFT"
+    side = "sell"
+    limit_price = 142.25
+    target_qty = 5.0
+
+    suffix = process_utils._format_float(limit_price, 4)
+    config_path = process_utils._watcher_config_path(symbol, side, "entry", suffix=suffix)
+
+    commands = []
+
+    def fake_popen(command, *args, **kwargs):
+        commands.append(command)
+        return SimpleNamespace(pid=11111)
+
+    monkeypatch.setattr(process_utils.subprocess, "Popen", fake_popen)
+
+    process_utils.spawn_open_position_at_maxdiff_takeprofit(
+        symbol,
+        side,
+        limit_price,
+        target_qty,
+        force_immediate=True,
+        priority_rank=2,
+    )
+
+    metadata = json.loads(config_path.read_text())
+    assert metadata["force_immediate"] is True
+    assert metadata["priority_rank"] == 2
+    assert any("--force-immediate" in cmd for cmd in commands)
+    assert any("--priority-rank=2" in cmd for cmd in commands)
 
 
 def test_spawn_close_replaces_existing_watcher(tmp_watchers_dir, monkeypatch):

--- a/trade_stock_e2e.py
+++ b/trade_stock_e2e.py
@@ -538,6 +538,9 @@ BACKOUT_MARKET_CLOSE_FORCE_MINUTES = int(os.getenv("BACKOUT_MARKET_CLOSE_FORCE_M
 MAXDIFF_ENTRY_WATCHER_POLL_SECONDS = max(5, int(os.getenv("MAXDIFF_ENTRY_POLL_SECONDS", "12")))
 MAXDIFF_EXIT_WATCHER_POLL_SECONDS = max(5, int(os.getenv("MAXDIFF_EXIT_POLL_SECONDS", "12")))
 MAXDIFF_EXIT_WATCHER_PRICE_TOLERANCE = float(os.getenv("MAXDIFF_EXIT_PRICE_TOLERANCE", "0.001"))
+MAXDIFF_ALWAYS_ON_PRIORITY_LIMIT = max(
+    0, int(os.getenv("MAXDIFF_ALWAYS_ON_PRIORITY_LIMIT", "2"))
+)
 
 
 def _log_detail(message: str) -> None:
@@ -2423,6 +2426,18 @@ def manage_positions(
 
     maxdiff_entries_seen = 0
 
+    always_on_candidates: List[Tuple[str, float]] = []
+    for symbol, pick_data in current_picks.items():
+        if pick_data.get("strategy") != "maxdiffalwayson":
+            continue
+        avg_return = coerce_numeric(pick_data.get("avg_return"), default=0.0)
+        always_on_candidates.append((symbol, avg_return))
+    always_on_candidates.sort(key=lambda item: item[1], reverse=True)
+    always_on_priority = {symbol: index + 1 for index, (symbol, _) in enumerate(always_on_candidates)}
+    always_on_forced_symbols = {
+        symbol for symbol, _ in always_on_candidates[:MAXDIFF_ALWAYS_ON_PRIORITY_LIMIT]
+    }
+
     for symbol, original_data in current_picks.items():
         data = dict(original_data)
         current_picks[symbol] = data
@@ -2439,6 +2454,23 @@ def manage_positions(
         else:
             data.pop("maxdiff_spread_rank", None)
             data.pop("maxdiff_spread_overflow", None)
+
+        priority_rank = None
+        force_immediate_entry = False
+        if data.get("strategy") == "maxdiffalwayson":
+            priority_rank = always_on_priority.get(symbol)
+            force_immediate_entry = symbol in always_on_forced_symbols
+            if priority_rank is not None:
+                data["maxdiffalwayson_priority_rank"] = priority_rank
+            else:
+                data.pop("maxdiffalwayson_priority_rank", None)
+            if force_immediate_entry:
+                data["maxdiffalwayson_force_immediate"] = True
+            else:
+                data.pop("maxdiffalwayson_force_immediate", None)
+        else:
+            data.pop("maxdiffalwayson_priority_rank", None)
+            data.pop("maxdiffalwayson_force_immediate", None)
         simplified_mode = SIMPLIFIED_MODE
         if simplified_mode:
             data["trade_mode"] = "normal"
@@ -2836,6 +2868,8 @@ def manage_positions(
                                     float(limit_price),
                                     float(target_qty),
                                     poll_seconds=MAXDIFF_ENTRY_WATCHER_POLL_SECONDS,
+                                    force_immediate=force_immediate_entry,
+                                    priority_rank=priority_rank,
                                 )
                                 if entry_strategy == "maxdiffalwayson":
                                     opposite_side = "sell" if is_buy_side(data["side"]) else "buy"
@@ -2885,6 +2919,8 @@ def manage_positions(
                                                     float(opposite_price),
                                                     float(target_qty),
                                                     poll_seconds=MAXDIFF_ENTRY_WATCHER_POLL_SECONDS,
+                                                    force_immediate=force_immediate_entry,
+                                                    priority_rank=priority_rank,
                                                 )
                                             except Exception as comp_exc:
                                                 logger.warning(


### PR DESCRIPTION
## Summary
- add priority ranking logic for maxdiffalwayson strategies so the top candidates bypass tolerance gating and carry priority metadata
- expose force-immediate and priority options through the shared process utilities, CLI watcher, and simulator state to keep subprocesses in sync
- extend regression coverage to assert the new metadata fields and priority-based behaviour

## Testing
- SKIP_TORCH_CHECK=1 pytest tests/prod/utils/test_process_utils.py
- SKIP_TORCH_CHECK=1 pytest tests/prod/trading/test_trade_stock_e2e.py::test_manage_positions_highlow_strategy_uses_limit_orders tests/prod/trading/test_trade_stock_e2e.py::test_manage_positions_highlow_short_uses_maxdiff_prices tests/prod/trading/test_trade_stock_e2e.py::test_manage_positions_prioritises_maxdiffalwayson_force_immediate


------
https://chatgpt.com/codex/tasks/task_e_6906a95095bc83339cd1c9d0706f87c3