### PR TITLE
fix: use Any in JSONDict to resolve ty type-check errors

### DIFF
--- a/rl_trading_agent_binance/trade_binance_live.py
+++ b/rl_trading_agent_binance/trade_binance_live.py
@@ -92,7 +92,7 @@ class BinanceSymbolConfig:
     max_position_pct: float = 0.20  # max % of portfolio in this symbol
 
 
-type JSONDict = dict[str, object]
+type JSONDict = dict[str, Any]
 type JSONList = list[JSONDict]
 
 


### PR DESCRIPTION
## Summary
- Changed `JSONDict` type alias from `dict[str, object]` to `dict[str, Any]` in `rl_trading_agent_binance/trade_binance_live.py`
- This fixes all 7 `ty` type-check errors (`invalid-argument-type`) where `object` values from dict access were passed to `float()`, which expects `ConvertibleToFloat`
- `dict[str, Any]` is the standard typing for JSON data in Python

## Test plan
- [x] Ran `ty check` locally on all CI-checked files — all checks passed
- [x] Verified the change is a single-line type alias fix with no runtime behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)